### PR TITLE
Support importing and exporting the diagram

### DIFF
--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -316,7 +316,7 @@ class MainWindow(QMainWindow):
                 except Exception as e:
                     msg = QMessageBox()
                     msg.setIcon(QMessageBox.Critical)
-                    msg.setText("Failed to convert the quantum circuit to ZX-diagram")
+                    msg.setText("Failed to convert the ZX-diagram to quantum circuit")
                     msg.setInformativeText(str(e))
                     msg.exec_()
                     return


### PR DESCRIPTION
# Summary
- Resolve #3 

## Details
- Supports importing & exporting the following files
  -  QGraph files as `*.zxg`
     - See: https://github.com/Quantomatic/zxlive/issues/3#issuecomment-1540013449
  -  TikZ files as `*.tikz`
  -  QASM files as `*.qasm`
  -  JSON files as `*.json`
- Shows an error message when importing failed.
- Shows an error message when a conversion from ZX-diagram to QASM failed.
