### PR TITLE
WIP: drag node command

### DIFF
--- a/zxlive/commands.py
+++ b/zxlive/commands.py
@@ -171,3 +171,19 @@ class ChangeColor(QUndoCommand):
         self.graph_view.set_graph(g)
 
     undo = redo = toggle
+
+
+class MoveNode(QUndoCommand):
+    def __init__(self, v, old_pos, new_pos):
+        super().__init__()
+        self.v = v
+        self.old_pos = old_pos
+        self.new_pos = new_pos
+
+    def redo(self):
+        self.v.set_position(*self.new_pos)
+        self.v.refresh()
+
+    def undo(self):
+        self.v.set_position(*self.old_pos)
+        self.v.refresh()


### PR DESCRIPTION
I've turned dragging into a command. Since dragging is continuous, using `undo_stack.begin_macro` and `undo_stack.end_macro` groups this into a single command.

Problem:
The `MoveNode` `QUndoCommand` takes `v, old_pos, new_pos` in the constructor, which means this is incompatible with the `SetGraph` command.

Any ideas?