### PR TITLE
Improved UI and refactoring

### DIFF
--- a/zxlive/edit_panel.py
+++ b/zxlive/edit_panel.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+
+from PySide6.QtGui import QAction, QActionGroup, QUndoStack
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QToolBar, QToolButton, QButtonGroup, QPushButton
+from pyzx import EdgeType, VertexType
+from pyzx.graph.base import BaseGraph, VT
+
+from .commands import AddEdge, AddNode, MoveNode
+from .graphscene import EditGraphScene, GraphScene
+from .graphview import GraphView
+
+
+class GraphEditPanel(QWidget):
+    """Panel for the edit mode of ZX live."""
+
+    graph: BaseGraph
+    graph_scene: EditGraphScene
+    graph_view: GraphView
+
+    toolbar: QToolBar
+    undo_stack: QUndoStack
+
+    _curr_ety: EdgeType = VertexType.Z
+    _curr_vty: VertexType = EdgeType.SIMPLE
+
+    def __init__(self, graph: BaseGraph) -> None:
+        super().__init__()
+        self.graph = graph
+
+        # Use box layout that fills the entire tab
+        self.setLayout(QVBoxLayout())
+        # self.layout().setContentsMargins(0, 0, 0, 0)
+        self.layout().setSpacing(0)
+
+        self.undo_stack = QUndoStack(self)
+
+        self.toolbar = QToolBar()
+        self.layout().addWidget(self.toolbar)
+
+        self.graph_scene = EditGraphScene(self._move_vert, self._add_vert, self._add_edge)
+        self.graph_view = GraphView(self.graph_scene)
+        self.graph_view.set_graph(self.graph)
+        self.layout().addWidget(self.graph_view)
+
+        self._populate_toolbar()
+
+    def _populate_toolbar(self) -> None:
+        undo = QToolButton(self, text="Undo")
+        redo = QToolButton(self, text="Redo")
+        undo.clicked.connect(self._undo_clicked)
+        redo.clicked.connect(self._redo_clicked)
+        for btn in (undo, redo):
+            self.toolbar.addWidget(btn)
+
+        self.toolbar.addSeparator()
+
+        vty_group = QButtonGroup(self, exclusive=True)
+        select_z = QToolButton(self, text="Z Spider", checkable=True, checked=True)  # Selected by default
+        select_x = QToolButton(self, text="X Spider", checkable=True)
+        select_boundary = QToolButton(self, text="Boundary", checkable=True)
+        select_z.clicked.connect(lambda _: self._select_vty(VertexType.Z))
+        select_x.clicked.connect(lambda _: self._select_vty(VertexType.X))
+        select_boundary.clicked.connect(lambda _: self._select_vty(VertexType.BOUNDARY))
+        for btn in (select_z, select_x, select_boundary):
+            self.toolbar.addWidget(btn)
+            vty_group.addButton(btn)
+
+        self.toolbar.addSeparator()
+
+        ety_group = QButtonGroup(self, exclusive=True)
+        select_simple = QToolButton(self, text="Simple Edge", checkable=True, checked=True)  # Selected by default
+        select_had = QToolButton(self, text="Had Edge", checkable=True)
+        select_simple.clicked.connect(lambda _: self._select_ety(EdgeType.SIMPLE))
+        select_had.clicked.connect(lambda _: self._select_ety(EdgeType.HADAMARD))
+        for btn in (select_simple, select_had):
+            self.toolbar.addWidget(btn)
+            ety_group.addButton(btn)
+
+        self.toolbar.addSeparator()
+
+        export = QToolButton(self, text="Export")
+        reset = QToolButton(self, text="Reset")
+        for btn in (export, reset):
+            self.toolbar.addWidget(btn)
+
+    def _select_vty(self, vty: VertexType) -> None:
+        self._curr_vty = vty
+
+    def _select_ety(self, ety: EdgeType) -> None:
+        self._curr_ety = ety
+        self.graph_scene.curr_ety = ety
+
+    def _undo_clicked(self):
+        self.undo_stack.undo()
+
+    def _redo_clicked(self):
+        self.undo_stack.redo()
+
+    def _add_vert(self, x: float, y: float) -> None:
+        cmd = AddNode(self.graph_view.graph_scene, x, y, self._curr_vty)
+        self.undo_stack.push(cmd)
+
+    def _add_edge(self, u: VT, v: VT) -> None:
+        cmd = AddEdge(self.graph_view.graph_scene, u, v, self._curr_ety)
+        self.undo_stack.push(cmd)
+
+    def _move_vert(self, v: VT, x: float, y: float):
+        cmd = MoveNode(self.graph_view.graph_scene, v, x, y)
+        self.undo_stack.push(cmd)
+

--- a/zxlive/graphview.py
+++ b/zxlive/graphview.py
@@ -28,8 +28,8 @@ class GraphView(QGraphicsView):
     interesting stuff happens in `GraphScene`.
     """
 
-    def __init__(self) -> None:
-        self.graph_scene = GraphScene()
+    def __init__(self, graph_scene: GraphScene) -> None:
+        self.graph_scene = graph_scene
         super().__init__(self.graph_scene)
         self.setMouseTracking(True)
         self.setRenderHint(QPainter.RenderHint.Antialiasing)

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -21,7 +21,7 @@ from pyzx.utils import VertexType
 import copy
 from fractions import Fraction
 
-
+from .edit_panel import GraphEditPanel
 from .graphview import GraphView
 from .rules import *
 from .construct import *
@@ -56,8 +56,17 @@ class MainWindow(QMainWindow):
             self.restoreGeometry(geom)
         self.show()
 
+        tab_widget = QTabWidget()
+        w.layout().addWidget(tab_widget)
+
+        graph = construct_circuit()
+        edit_panel = GraphEditPanel(graph)
+        tab_widget.addTab(edit_panel, "Edit")
+
+        return
+
         # add a GraphView as the only widget in the window
-        self.graph_view = GraphView()
+        self.graph_view = GraphView(GraphScene())
         w.layout().addWidget(self.graph_view)
 
         self.graph_view.set_graph(construct_circuit())


### PR DESCRIPTION
This work in progress PR implements some of the suggestions from #10. Once finished, this will also fix #22, #28

I moved and refactored the graph editing code into a separate `GraphEditPanel` accessible via a tab widget and updated the UI. 

Also various other bits and pieces:

- [x] Move graph manipulation and undo stack out of the `GraphScene`
- [x] Selection UI for current vertex type that is added via right click
- [x] Selection UI for current edge type that is added via right drag
- [x] Draw edge when dragging
- [x] Update vertex locations in graph when moving (fixes issue where nodes "jump back" into their old position after applying rewrite)
- [x] Make moving of vertices undoable
- [ ] Proof panel
- [ ] Remove old code

This is still work in progress, but comments are welcome (in particular regarding UI)