### PR TITLE
force graph to be up to date in edge if it changes type

### DIFF
--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -53,9 +53,10 @@ class EItem(QGraphicsPathItem):
 
         self.refresh()
 
-    def refresh(self) -> None:
+    def refresh(self, g=None) -> None:
         """Call whenever source or target moves or edge data changes"""
-
+        if g is not None:
+            self.g = g
         # set color/style according to edge type
         pen = QPen()
         pen.setWidthF(3)

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -158,7 +158,7 @@ class GraphScene(QGraphicsScene):
             v_item.set_pos_from_graph()
 
         for e in diff.changed_edge_types:
-            self.edge_map[e].refresh()
+            self.edge_map[e].refresh(new)
 
         self.select_vertices(selected_vertices)
 


### PR DESCRIPTION
very ugly feeling way to fix edge type update not showing (but also I'm not sure where else the graph should be getting updated, since it seems like it may need to be fully recreated to get the update (eg when spider fusing it))