### PR TITLE
Fix edge type update

### DIFF
--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -26,18 +26,21 @@ from pyzx import EdgeType
 from .common import SCALE, VT, ET, GraphT
 from .vitem import VItem, EITEM_Z
 
+if TYPE_CHECKING:
+    from .graphscene import GraphScene
+
 HAD_EDGE_BLUE = "#0077ff"
 
 class EItem(QGraphicsPathItem):
     """A QGraphicsItem representing an edge"""
 
-    def __init__(self, g: GraphT, e: ET, s_item: VItem, t_item: VItem) -> None:
+    def __init__(self, graph_scene: GraphScene, e: ET, s_item: VItem, t_item: VItem) -> None:
         super().__init__()
         self.setZValue(EITEM_Z)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemSendsGeometryChanges, True)
 
-        self.g = g
+        self.graph_scene = graph_scene
         self.e = e
         self.s_item = s_item
         self.t_item = t_item
@@ -52,6 +55,10 @@ class EItem(QGraphicsPathItem):
         # self.selection_node.setVisible(False)
 
         self.refresh()
+
+    @property
+    def g(self) -> GraphT:
+        return self.graph_scene.g
 
     def refresh(self) -> None:
         """Call whenever source or target moves or edge data changes"""

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -138,7 +138,7 @@ class GraphScene(QGraphicsScene):
 
         for e in diff.new_edges:
             s, t = self.g.edge_st(e)
-            e_item = EItem(self.g, e, self.vertex_map[s], self.vertex_map[t])
+            e_item = EItem(self, e, self.vertex_map[s], self.vertex_map[t])
             self.edge_map[e] = e_item
             self.addItem(e_item)
             self.addItem(e_item.selection_node)
@@ -174,7 +174,7 @@ class GraphScene(QGraphicsScene):
         self.edge_map = {}
         for e in self.g.edges():
             s, t = self.g.edge_st(e)
-            ei = EItem(self.g, e, self.vertex_map[s], self.vertex_map[t])
+            ei = EItem(self, e, self.vertex_map[s], self.vertex_map[t])
             self.addItem(ei)
             self.addItem(ei.selection_node)
             self.edge_map[e] = ei


### PR DESCRIPTION
This PR fixes #49 by storing the `GraphScene` instead of the graph itself in `EItem`. This way, the edge item has access to the updated graph

This should also resolve #51