### PR TITLE
Temporarily disable `is_well_formed` check.

### DIFF
--- a/zxlive/edit_panel.py
+++ b/zxlive/edit_panel.py
@@ -58,9 +58,10 @@ class GraphEditPanel(EditorBasePanel):
         yield ToolbarSection(self.start_derivation)
 
     def _start_derivation(self) -> None:
-        if not self.graph_scene.g.is_well_formed():
-            show_error_msg("Graph is not well-formed")
-            return
+        # TODO: re-enable after https://github.com/Quantomatic/pyzx/pull/162
+        # if not self.graph_scene.g.is_well_formed():
+        #     show_error_msg("Graph is not well-formed")
+        #     return
         new_g: GraphT = copy.deepcopy(self.graph_scene.g)
         for vert in new_g.vertices():
             phase = new_g.phase(vert)


### PR DESCRIPTION
This should be re-enabled after https://github.com/Quantomatic/pyzx/pull/162 is merged.