### PR TITLE
Fix typo in settings dialog code that prevents float settings from proper initialisation.

### DIFF
--- a/zxlive/settings_dialog.py
+++ b/zxlive/settings_dialog.py
@@ -137,7 +137,7 @@ class SettingsDialog(QDialog):
             widget.setValue(val)
         elif ty == 'float':
             widget = QDoubleSpinBox()
-            val = float(int)
+            val = float(val)
             widget.setValue(val)
         
         form.addRow(label, widget)


### PR DESCRIPTION
(Doesn't actually affect anything at the moment as there are no float settings, but presumably there will be in the future.)