### PR TITLE
For fractional phase with variables, accept an integer or fraction followed by a variable (without an intervening "*").

### DIFF
--- a/test/test_editor_base_panel.py
+++ b/test/test_editor_base_panel.py
@@ -58,6 +58,15 @@ def test_string_to_fraction() -> None:
     # Test a fractional phase specified with variables.
     assert (string_to_fraction('a*b', _new_var) ==
             Poly([(1, Term([(Var('a', types_dict), 1), (Var('b', types_dict), 1)]))]))
+    assert (string_to_fraction('2*a', _new_var) ==
+            Poly([(2, Term([(Var('a', types_dict), 1)]))]))
+    assert (string_to_fraction('2a', _new_var) ==
+            Poly([(2, Term([(Var('a', types_dict), 1)]))]))
+    assert (string_to_fraction('3/2a', _new_var) ==
+            Poly([(3/2, Term([(Var('a', types_dict), 1)]))]))
+    assert (string_to_fraction('3a+2b', _new_var) ==
+            Poly([(3, Term([(Var('a', types_dict), 1)])), (2, Term([(Var('b', types_dict), 1)]))]))
+
 
     # Test bad input.
     with pytest.raises(ValueError):

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -168,7 +168,7 @@ class EditorBasePanel(BasePanel):
 
         else:
             prompt = "Enter desired phase value (in units of pi):"
-            error_msg = "Please enter a valid input (e.g., 1/2, 2, 0.25, a)."
+            error_msg = "Please enter a valid input (e.g., 1/2, 2, 0.25, 2a+b)."
 
         input_, ok = QInputDialog.getText(
             self, "Change Phase", prompt

--- a/zxlive/parse_poly.py
+++ b/zxlive/parse_poly.py
@@ -8,7 +8,7 @@ from fractions import Fraction
 
 poly_grammar = Lark("""
     start      : "(" start ")" | term ("+" term)*
-    term       : factor ("*" factor)*
+    term       : (intf | frac)? factor ("*" factor)*
     ?factor    : intf | frac | pi | pifrac | var
     var        : CNAME
     intf       : INT


### PR DESCRIPTION
For example: `3alpha` and `1/2beta` as shorthands for `3*alpha` and `1/2*beta`. The former are how these phases are displayed in the UI, so it makes intuitive sense to accept them as input.

See issue #148.