### PR TITLE
Make the spelling of "ZXLive" and "ZX-calculus" consistent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The [ZX calculus](http://zxcalculus.com) gives us a handy way to represent and work with quantum computations. ZXLive is an interactive tool for working with ZX. Draw graphs or load circuits and apply ZX rules. Intended for experimenting, building proofs, helping to write papers, showing off, or simply learning about ZX and quantum computing. It is powered by the [pyzx](https://github.com/Quantomatic/pyzx) open source library under the hood.
+The [ZX-calculus](http://zxcalculus.com) gives us a handy way to represent and work with quantum computations. ZXLive is an interactive tool for working with ZX. Draw graphs or load circuits and apply ZX rules. Intended for experimenting, building proofs, helping to write papers, showing off, or simply learning about ZX and quantum computing. It is powered by the [pyzx](https://github.com/Quantomatic/pyzx) open source library under the hood.
 
 This project is in a pretty early stage, with lots more to come. Have a look at the [Issue Tracker](https://github.com/Quantomatic/zxlive/issues) to see what's in the pipeline.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The [ZX calculus](http://zxcalculus.com) gives us a handy way to represent and work with quantum computations. ZX Live is an interactive tool for working with ZX. Draw graphs or load circuits and apply ZX rules. Intended for experimenting, building proofs, helping to write papers, showing off, or simply learning about ZX and quantum computing. It is powered by the [pyzx](https://github.com/Quantomatic/pyzx) open source library under the hood.
+The [ZX calculus](http://zxcalculus.com) gives us a handy way to represent and work with quantum computations. ZXLive is an interactive tool for working with ZX. Draw graphs or load circuits and apply ZX rules. Intended for experimenting, building proofs, helping to write papers, showing off, or simply learning about ZX and quantum computing. It is powered by the [pyzx](https://github.com/Quantomatic/pyzx) open source library under the hood.
 
 This project is in a pretty early stage, with lots more to come. Have a look at the [Issue Tracker](https://github.com/Quantomatic/zxlive/issues) to see what's in the pipeline.
 
@@ -11,5 +11,5 @@ To install from source, you need Python >= 3.9 and pip. If you have those, just 
     cd zxlive
     pip install .
 
-Then, you can run ZX Live by typing `python3 -m zxlive`.
+Then, you can run ZXLive by typing `python3 -m zxlive`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "zxlive"
 version = "0.1"
-description = "An interactive tool for the ZX calculus"
+description = "An interactive tool for the ZX-calculus"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_editor_base_panel.py
+++ b/test/test_editor_base_panel.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_mainwindow.py
+++ b/test/test_mainwindow.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/__init__.py
+++ b/zxlive/__init__.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/__main__.py
+++ b/zxlive/__main__.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/app.py
+++ b/zxlive/app.py
@@ -24,22 +24,22 @@ sys.path.insert(0, '../pyzx')  # So that it can find a local copy of pyzx
 
 
 class ZXLive(QApplication):
-    """The main ZX Live application
+    """The main ZXLive application
 
     ...
     """
 
     def __init__(self) -> None:
         super().__init__(sys.argv)
-        self.setApplicationName('ZX Live')
-        self.setDesktopFileName('ZX Live')
+        self.setApplicationName('ZXLive')
+        self.setDesktopFileName('ZXLive')
         self.setApplicationVersion('0.1')  # TODO: read this from pyproject.toml if possible
         self.main_window = MainWindow()
 
         self.lastWindowClosed.connect(self.quit)
 
         parser = QCommandLineParser()
-        parser.setApplicationDescription("ZX Live - An interactive tool for the ZX calculus")
+        parser.setApplicationDescription("ZXLive - An interactive tool for the ZX calculus")
         parser.addHelpOption()
         parser.addVersionOption()
         parser.addPositionalArgument("files", "File(s) to open.", "[files...]")
@@ -49,7 +49,7 @@ class ZXLive(QApplication):
 
 
 def main() -> None:
-    """Main entry point for ZX Live"""
+    """Main entry point for ZXLive"""
 
     zxl = ZXLive()
     zxl.exec_()

--- a/zxlive/app.py
+++ b/zxlive/app.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ class ZXLive(QApplication):
         self.lastWindowClosed.connect(self.quit)
 
         parser = QCommandLineParser()
-        parser.setApplicationDescription("ZXLive - An interactive tool for the ZX calculus")
+        parser.setApplicationDescription("ZXLive - An interactive tool for the ZX-calculus")
         parser.addHelpOption()
         parser.addVersionOption()
         parser.addPositionalArgument("files", "File(s) to open.", "[files...]")

--- a/zxlive/edit_panel.py
+++ b/zxlive/edit_panel.py
@@ -18,7 +18,7 @@ from .poly import Poly
 
 
 class GraphEditPanel(EditorBasePanel):
-    """Panel for the edit mode of ZX live."""
+    """Panel for the edit mode of ZXLive."""
 
     graph_scene: EditGraphScene
     start_derivation_signal = Signal(object)

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -59,7 +59,7 @@ EDGES: dict[EdgeType.Type, DrawPanelNodeType] = {
 
 class EditorBasePanel(BasePanel):
     """Base class implementing the shared functionality of graph edit
-    and rule edit panels of ZX live."""
+    and rule edit panels of ZXLive."""
 
     graph_scene: EditGraphScene
     start_derivation_signal = Signal(object)

--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/graphview.py
+++ b/zxlive/graphview.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -31,7 +31,7 @@ from .vitem import DragState, VItem
 
 
 class ProofPanel(BasePanel):
-    """Panel for the proof mode of ZX live."""
+    """Panel for the proof mode of ZXLive."""
 
     def __init__(self, graph: GraphT, *actions: QAction) -> None:
         super().__init__(*actions)

--- a/zxlive/rule_panel.py
+++ b/zxlive/rule_panel.py
@@ -18,7 +18,7 @@ from .poly import Poly
 
 
 class RulePanel(EditorBasePanel):
-    """Panel for the Rule editor of ZX live."""
+    """Panel for the Rule editor of ZXLive."""
 
     graph_scene_left: EditGraphScene
     graph_scene_right: EditGraphScene

--- a/zxlive/settings_dialog.py
+++ b/zxlive/settings_dialog.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -1,4 +1,4 @@
-#     zxlive - An interactive tool for the ZX calculus
+#     zxlive - An interactive tool for the ZX-calculus
 #     Copyright (C) 2023 - Aleks Kissinger
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The description in github, which currently says "A graphical tool for the ZX calculus", will also need to be updated to match this change.