### PR TITLE
Clean up some variables not actually used in `MainWindow`

### DIFF
--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -248,13 +248,13 @@ def export_proof_dialog(parent: QWidget) -> Optional[str]:
 
 def get_lemma_name_and_description(parent: MainWindow) -> tuple[Optional[str], Optional[str]]:
     dialog = QDialog()
-    parent.rewrite_form = QFormLayout(dialog)
+    rewrite_form = QFormLayout(dialog)
     name = QLineEdit()
-    parent.rewrite_form.addRow("Name", name)
+    rewrite_form.addRow("Name", name)
     description = QTextEdit()
-    parent.rewrite_form.addRow("Description", description)
+    rewrite_form.addRow("Description", description)
     button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
-    parent.rewrite_form.addRow(button_box)
+    rewrite_form.addRow(button_box)
     button_box.accepted.connect(dialog.accept)
     button_box.rejected.connect(dialog.reject)
     if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -263,36 +263,37 @@ def get_lemma_name_and_description(parent: MainWindow) -> tuple[Optional[str], O
 
 def create_new_rewrite(parent: MainWindow) -> None:
     dialog = QDialog()
-    parent.rewrite_form = QFormLayout(dialog)
+    rewrite_form = QFormLayout(dialog)
     name = QLineEdit()
-    parent.rewrite_form.addRow("Name", name)
+    rewrite_form.addRow("Name", name)
     description = QTextEdit()
-    parent.rewrite_form.addRow("Description", description)
+    rewrite_form.addRow("Description", description)
     left_button = QPushButton("Left-hand side of the rule")
     right_button = QPushButton("Right-hand side of the rule")
-    parent.left_graph = None
-    parent.right_graph = None
+    left_graph = None
+    right_graph = None
 
     def get_file(self: MainWindow, button: QPushButton, side: str) -> None:
+        nonlocal left_graph, right_graph
         out = import_diagram_dialog(self)
         if out is not None and isinstance(out, ImportGraphOutput):
             button.setText(out.file_path)
             if side == "left":
-                self.left_graph = out.g
+                left_graph = out.g
             else:
-                self.right_graph = out.g
+                right_graph = out.g
 
     left_button.clicked.connect(lambda: get_file(parent, left_button, "left"))
     right_button.clicked.connect(lambda: get_file(parent, right_button, "right"))
-    parent.rewrite_form.addRow(left_button)
-    parent.rewrite_form.addRow(right_button)
+    rewrite_form.addRow(left_button)
+    rewrite_form.addRow(right_button)
     button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
-    parent.rewrite_form.addRow(button_box)
+    rewrite_form.addRow(button_box)
     def add_rewrite() -> None:
-        if parent.left_graph is None or parent.right_graph is None or \
-            name.text() == "" or description.toPlainText() == "":
+        nonlocal left_graph, right_graph
+        if left_graph is None or right_graph is None or name.text() == "" or description.toPlainText() == "":
             return
-        rule = CustomRule(parent.left_graph, parent.right_graph, name.text(), description.toPlainText())
+        rule = CustomRule(left_graph, right_graph, name.text(), description.toPlainText())
         check_rule(rule, show_error=True)
         if safe_rule_dialog(rule, parent):
             dialog.accept()

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -48,10 +48,6 @@ from .tikz import proof_to_tikz
 class MainWindow(QMainWindow):
     """The main window of the ZXLive application."""
 
-    rewrite_form: QFormLayout
-    left_graph: Optional[GraphT]
-    right_graph: Optional[GraphT]
-
     def __init__(self) -> None:
         super().__init__()
         self.settings = QSettings("zxlive", "zxlive")

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Callable, Optional, TypedDict
+from typing import Callable, Optional
 
 from PySide6.QtCore import (QByteArray, QEvent, QFile, QFileInfo, QIODevice,
                             QSettings, QTextStream, Qt)
@@ -24,13 +24,10 @@ from PySide6.QtGui import QAction, QCloseEvent, QIcon, QKeySequence
 from PySide6.QtWidgets import (QDialog, QFormLayout, QMainWindow, QMessageBox,
                                QTableWidget, QTableWidgetItem, QTabWidget,
                                QVBoxLayout, QWidget)
-from pyzx import extract_circuit, simplify
-from pyzx.graph.base import BaseGraph
 
 import pyperclip
 
 from .base_panel import BasePanel
-from .commands import AddRewriteStep
 from .common import GraphT, get_data, to_tikz, from_tikz
 from .construct import *
 from .custom_rule import CustomRule, check_rule
@@ -42,7 +39,6 @@ from .dialogs import (FileFormat, ImportGraphOutput, ImportProofOutput,
                       export_proof_dialog)
 from zxlive.settings_dialog import open_settings_dialog
 
-from .editor_base_panel import EditorBasePanel
 from .edit_panel import GraphEditPanel
 from .proof_panel import ProofPanel
 from .rule_panel import RulePanel
@@ -52,8 +48,6 @@ from .tikz import proof_to_tikz
 class MainWindow(QMainWindow):
     """The main window of the ZXLive application."""
 
-    edit_panel: GraphEditPanel
-    proof_panel: ProofPanel
     rewrite_form: QFormLayout
     left_graph: Optional[GraphT]
     right_graph: Optional[GraphT]


### PR DESCRIPTION
I haven't thoroughly tested the "rewrite" code as I don't understand the typcial workflow, but purely looking at the code, there doesn't seem to be any reason why `rewrite_form`, `left_graph`, and `right_graph` should be owned by `MainWindow` rather than by the only functions in which they're used.

