### PR TITLE
Save proofs as JSON rather than Tikz

### DIFF
--- a/zxlive/proof.py
+++ b/zxlive/proof.py
@@ -119,7 +119,7 @@ class ProofModel(QAbstractListModel):
 
     def to_json(self) -> str:
         """Serializes the model to JSON."""
-        initial_graph_tikz = self.graphs[0].to_tikz()
+        initial_graph_tikz = self.graphs[0].to_json()
         proof_steps = []
         for step in self.steps:
             proof_steps.append(step.to_json())
@@ -132,7 +132,7 @@ class ProofModel(QAbstractListModel):
     def from_json(json_str: str) -> "ProofModel":
         """Deserializes the model from JSON."""
         d = json.loads(json_str)
-        initial_graph = GraphT.from_tikz(d["initial_graph"])
+        initial_graph = GraphT.from_json(d["initial_graph"])
         # Mypy issue: https://github.com/python/mypy/issues/11673
         assert isinstance(initial_graph, GraphT)  # type: ignore
         model = ProofModel(initial_graph)


### PR DESCRIPTION
This resolves a bug where proofs with a phase spider with a parameter will produce an error.

Steps to reproduce:
1. Add a phase with the symbol "a" to a spider
2. Start a proof
3. Save the proof and attempt to open it

It will complain that the proof file is unable to be opened
<img width="263" alt="Screenshot 2023-11-22 at 11 49 37 am" src="https://github.com/Quantomatic/zxlive/assets/44865292/1d142d8d-9507-4dc7-a3d1-286e39bb71a0">
<img width="331" alt="Screenshot 2023-11-22 at 11 49 47 am" src="https://github.com/Quantomatic/zxlive/assets/44865292/0738e1dd-615c-405c-a9da-b6508940a123">
