### PR TITLE
Remove unused imports

### DIFF
--- a/test/test_editor_base_panel.py
+++ b/test/test_editor_base_panel.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 
-from fractions import Fraction
-
 import pytest
 
 from zxlive.editor_base_panel import string_to_complex

--- a/zxlive/common.py
+++ b/zxlive/common.py
@@ -1,6 +1,6 @@
 import os
 from enum import IntEnum
-from typing import Final, Optional
+from typing import Final
 from typing_extensions import TypeAlias
 
 from PySide6.QtCore import QSettings

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import re
 from enum import Enum
 from typing import Callable, Iterator, TypedDict
 

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -21,7 +21,7 @@ from typing import Callable, Optional
 from PySide6.QtCore import (QByteArray, QEvent, QFile, QFileInfo, QIODevice,
                             QSettings, QTextStream, Qt)
 from PySide6.QtGui import QAction, QCloseEvent, QIcon, QKeySequence
-from PySide6.QtWidgets import (QDialog, QFormLayout, QMainWindow, QMessageBox,
+from PySide6.QtWidgets import (QDialog, QMainWindow, QMessageBox,
                                QTableWidget, QTableWidgetItem, QTabWidget,
                                QVBoxLayout, QWidget)
 

--- a/zxlive/settings_dialog.py
+++ b/zxlive/settings_dialog.py
@@ -15,12 +15,12 @@
 
 from __future__ import annotations
 
-from typing import Optional,TYPE_CHECKING, Dict, Any
+from typing import TYPE_CHECKING, Dict, Any
 
-from PySide6.QtCore import QFile, QIODevice, QTextStream, QSettings, Qt
-from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QFileDialog,
-                               QFormLayout, QLineEdit, QMessageBox,
-                               QPushButton, QTextEdit, QWidget,
+from PySide6.QtCore import QSettings
+from PySide6.QtWidgets import (QDialog, QFileDialog,
+                               QFormLayout, QLineEdit,
+                               QPushButton, QWidget,
                                QVBoxLayout, QSpinBox, QDoubleSpinBox,
                                QLabel, QHBoxLayout, QTabWidget,
                                 QComboBox)


### PR DESCRIPTION
Remove unused imports which were discovered by using `pylint` with the following `.pylintrc` file.

```
[MESSAGES CONTROL]
disable=C, F, I, R, W
```