### PR TITLE
Add ability to rename proof steps

### DIFF
--- a/zxlive/commands.py
+++ b/zxlive/commands.py
@@ -47,6 +47,18 @@ class BaseCommand(QUndoCommand):
         #  we could store "dirty flags" for each node/edge.
         self.graph_view.update_graph(self.g, select_new)
 
+@dataclass
+class UndoableChange(BaseCommand):
+    """ Generic undoable change in the graph that can be appended to the
+    undo stack
+
+    Can be initialised as: UndoableChange(<parent>, <undo_cmd>, <redo_cmd>)
+
+    Where <parent> must contain the graph_view attribute as it is used in
+    BaseCommand.
+    """
+    undo: Callable[[], None]
+    redo: Callable[[], None]
 
 @dataclass
 class SetGraph(BaseCommand):
@@ -370,7 +382,7 @@ class AddRewriteStep(SetGraph):
             self._old_steps.append(self.proof_model.pop_rewrite())
 
         diff = self.diff or GraphDiff(self.g, self.new_g)
-        self.proof_model.add_rewrite(Rewrite(self.name, diff), self.new_g)
+        self.proof_model.add_rewrite(Rewrite(self.name, self.name, diff), self.new_g)
 
         # Select the added step
         idx = self.step_view.model().index(self.proof_model.rowCount() - 1, 0, QModelIndex())


### PR DESCRIPTION
Doubling clicking on the proof step will open a dialog prompting a new name for the proof step.

A separate display name attribute was added to the Rewrite class rather than modifying the "rule" attribute since "rule" is used when converting a proof to a tikz diagram.

This change is backwards compatible since old versions of zxlive with new proof files will ignore the `display_name` attribute and behave as usual, and new versions of zxlive given an old proof file will set the `display_name` to be the name of the rule if it is not present

Fixes #189.