### PR TITLE
Add comment to note quirk about qubit numbering of the demo graph.

### DIFF
--- a/zxlive/construct.py
+++ b/zxlive/construct.py
@@ -6,6 +6,10 @@ from .common import GraphT
 def construct_circuit() -> GraphT:
     qubits = 4
 
+    # Note: The qubit numbers in the graph which is returned from this function
+    # will be 4 plus the numbers in vlist and elist, since the input nodes are
+    # numbered from 0 to 3.
+
     # id, qubit number, vertex type (1 = Z, 2 = X).
     vlist = [
         (0, 0, 1), (1, 1, 2), (2, 2, 1), (3, 3, 1), (4, 0, 1), (5, 1, 1),


### PR DESCRIPTION
The way the graph is initialised can be confusing to someone using the demo graph to debug, since the qubit numbering used in the actual graph is shifted by 4 from the numbering in the lists used to initialise it (due to the 4 added input nodes).

See https://github.com/Quantomatic/zxlive/pull/213#issuecomment-1859038786 for context.