### PR TITLE
Enlarge circuit element icons to prevent cropping

### DIFF
--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -322,7 +322,6 @@ def create_list_widget(parent: EditorBasePanel,
     list_widget.setViewMode(QListView.ViewMode.IconMode)
     list_widget.setMovement(QListView.Movement.Static)
     list_widget.setUniformItemSizes(True)
-    list_widget.setGridSize(QSize(60, 64))
     list_widget.setWordWrap(True)
     list_widget.setIconSize(QSize(24, 24))
     populate_list_widget(list_widget, data, onclick, ondoubleclick)


### PR DESCRIPTION
The Hadamard wire's name was being cropped as Hadam...

<img width="79" alt="Screenshot 2023-12-17 at 8 42 26 pm" src="https://github.com/Quantomatic/zxlive/assets/44865292/c9fc582e-a300-499d-88a1-5d10e5503ad2">

After enlarging the icons by 5 pixels, it becomes

<img width="93" alt="Screenshot 2023-12-17 at 8 42 11 pm" src="https://github.com/Quantomatic/zxlive/assets/44865292/ef5d973c-2482-4b6a-9047-67b55db86c41">

This was to resolve #164, but on my machine all the other circuit element's names were displayed in full. I'm not sure if this is a OS issue (I'm on Mac 14) or it was resolved in a previous commit.