### PR TITLE
Fix a bug where "bialgebra" under "Simplification routines" causes a crash.

### DIFF
--- a/zxlive/rewrite_data.py
+++ b/zxlive/rewrite_data.py
@@ -97,7 +97,7 @@ def _extract_circuit(graph: GraphT, matches: list) -> GraphT:
 
 simplifications: dict[str, RewriteData] = {
     'bialg_simp': {
-        "text": "bialgebra",
+        "text": "bialgebra simp",
         "tooltip": "bialg_simp",
         "matcher": const_true,
         "rule": apply_simplification(simplify.bialg_simp),


### PR DESCRIPTION
Because it has the same name as "bialgebra" under "Basic rules", the `make_animation` function attempts to perform the incorrect animation. This crashes as the matcher for `bialg_simp`, which is `const_true` , returns the wrong type (`Callable[..., Any]` rather than the expected `List[Any]`).

See https://github.com/Quantomatic/zxlive/issues/132#issuecomment-1814408236 for context.