### PR TITLE
Fixes crash due to accessing selection after graph_scene is deleted #218

### DIFF
--- a/zxlive/base_panel.py
+++ b/zxlive/base_panel.py
@@ -106,3 +106,7 @@ class BasePanel(QWidget):
 
     def update_colors(self) -> None:
         self.graph_scene.update_colors()
+
+    def shutdown(self):
+        if hasattr(self, 'graph_scene'):
+            self.graph_scene.shutdown()    

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -76,9 +76,9 @@ class ImportRuleOutput:
     file_path: str
     r: CustomRule
 
-def show_error_msg(title: str, description: Optional[str] = None) -> None:
+def show_error_msg(title: str, description: Optional[str] = None, parent: Optional[QWidget] = None) -> None:
     """Displays an error message box."""
-    msg = QMessageBox()
+    msg = QMessageBox(parent) # Set the parent of the QMessageBox
     msg.setText(title)
     msg.setIcon(QMessageBox.Icon.Critical)
     if description is not None:
@@ -108,14 +108,14 @@ def create_circuit_dialog(explanation: str, example: str, parent: QWidget) -> Op
     return s if success else None
 
 
-def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.All.filter) -> \
+def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.All.filter, parent: Optional[QWidget] = None) -> \
         Optional[ImportGraphOutput | ImportProofOutput | ImportRuleOutput]:
     """Imports a diagram from a given file path.
 
     Returns the imported graph or `None` if the import failed."""
     file = QFile(file_path)
     if not file.open(QIODevice.OpenModeFlag.ReadOnly | QIODevice.OpenModeFlag.Text):
-        show_error_msg(f"Could not open file: {file_path}.")
+        show_error_msg(f"Could not open file: {file_path}.", parent=parent)
         return None
     stream = QTextStream(file)
     data = stream.readAll()

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -76,9 +76,9 @@ class ImportRuleOutput:
     file_path: str
     r: CustomRule
 
-def show_error_msg(title: str, description: Optional[str] = None, parent: Optional[QWidget] = None) -> None:
+def show_error_msg(title: str, description: Optional[str] = None) -> None:
     """Displays an error message box."""
-    msg = QMessageBox(parent) # Set the parent of the QMessageBox
+    msg = QMessageBox()
     msg.setText(title)
     msg.setIcon(QMessageBox.Icon.Critical)
     if description is not None:
@@ -108,14 +108,14 @@ def create_circuit_dialog(explanation: str, example: str, parent: QWidget) -> Op
     return s if success else None
 
 
-def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.All.filter, parent: Optional[QWidget] = None) -> \
+def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.All.filter) -> \
         Optional[ImportGraphOutput | ImportProofOutput | ImportRuleOutput]:
     """Imports a diagram from a given file path.
 
     Returns the imported graph or `None` if the import failed."""
     file = QFile(file_path)
     if not file.open(QIODevice.OpenModeFlag.ReadOnly | QIODevice.OpenModeFlag.Text):
-        show_error_msg(f"Could not open file: {file_path}.", parent=parent)
+        show_error_msg(f"Could not open file: {file_path}.")
         return None
     stream = QTextStream(file)
     data = stream.readAll()

--- a/zxlive/edit_panel.py
+++ b/zxlive/edit_panel.py
@@ -106,3 +106,7 @@ class GraphEditPanel(EditorBasePanel):
             cmd = UpdateGraph(self.graph_view, new_g)
             self.undo_stack.push(cmd)
             self.graph_scene.select_vertices(new_verts)
+
+    def shutdown(self):
+        if hasattr(self, 'graph_scene'):
+            self.graph_scene.shutdown() 

--- a/zxlive/edit_panel.py
+++ b/zxlive/edit_panel.py
@@ -106,7 +106,3 @@ class GraphEditPanel(EditorBasePanel):
             cmd = UpdateGraph(self.graph_view, new_g)
             self.undo_stack.push(cmd)
             self.graph_scene.select_vertices(new_verts)
-
-    def shutdown(self):
-        if hasattr(self, 'graph_scene'):
-            self.graph_scene.shutdown() 

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -195,6 +195,20 @@ class GraphScene(QGraphicsScene):
         for it in self.items():
             it.setSelected(True)
 
+    def shutdown(self):
+
+        """
+        Perform necessary cleanup to avoid RunTimeError when the application closes.
+        Call this method before the application closes. 
+        """        
+
+        #Clear all items from the scene to ensure no dangling references remain
+        self.clear()
+
+
+        #explicity remove references to Qt object that may be deleted
+        self.vertex_map.clear()
+        self.edge_map.clear()
 
 class EditGraphScene(GraphScene):
     """A graph scene tracking additional mouse events for graph editing."""

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -201,11 +201,8 @@ class GraphScene(QGraphicsScene):
         Perform necessary cleanup to avoid RunTimeError when the application closes.
         Call this method before the application closes. 
         """        
-
         #Clear all items from the scene to ensure no dangling references remain
         self.clear()
-
-
         #explicity remove references to Qt object that may be deleted
         self.vertex_map.clear()
         self.edge_map.clear()

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -223,6 +223,12 @@ class MainWindow(QMainWindow):
 
 
     def closeEvent(self, e: QCloseEvent) -> None:
+        #Call shutdown on all tabs before closing
+        for i in range(self.tab_widget.count()):
+            widget = self.tab_widget.widget(i)
+            if isinstance(widget, BasePanel):
+                widget.shutdown()
+
         while self.active_panel is not None:  # We close all the tabs and ask the user if they want to save progress
             success = self.handle_close_action()
             if not success:

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -421,6 +421,10 @@ class ProofPanel(BasePanel):
         # TODO: Right now this calls for every single vertex selected, even if we select many at the same time
         self.graph_scene.selectionChanged.connect(model.update_on_selection)
 
+    def shutdown(self):
+        if hasattr(self, 'graph_scene'):
+            self.graph_scene.shutdown() 
+
 
 class ProofStepItemDelegate(QStyledItemDelegate):
     """This class controls the painting of items in the proof steps list view.

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -421,11 +421,6 @@ class ProofPanel(BasePanel):
         # TODO: Right now this calls for every single vertex selected, even if we select many at the same time
         self.graph_scene.selectionChanged.connect(model.update_on_selection)
 
-    def shutdown(self):
-        if hasattr(self, 'graph_scene'):
-            self.graph_scene.shutdown() 
-
-
 class ProofStepItemDelegate(QStyledItemDelegate):
     """This class controls the painting of items in the proof steps list view.
 

--- a/zxlive/rule_panel.py
+++ b/zxlive/rule_panel.py
@@ -80,3 +80,7 @@ class RulePanel(EditorBasePanel):
                           self.graph_scene_right.g,
                           self.name_field.text(),
                           self.description_field.text())
+    
+    def shutdown(self):
+        if hasattr(self, 'graph_scene'):
+            self.graph_scene.shutdown() 

--- a/zxlive/rule_panel.py
+++ b/zxlive/rule_panel.py
@@ -81,6 +81,3 @@ class RulePanel(EditorBasePanel):
                           self.name_field.text(),
                           self.description_field.text())
     
-    def shutdown(self):
-        if hasattr(self, 'graph_scene'):
-            self.graph_scene.shutdown() 


### PR DESCRIPTION
### Summary 
The `MainWindow `class is where I integrated the cleanup routine for the `GraphScene`. `MainWindow` has already a `closeEvent` method. This is where we call the shutdown method of each `GraphScene` instance before the application closes. However, the `GraphScene` instances are not directly managed by `MainWindow` but rather by the panels like `GraphEditPanel`, `ProofPanel`, and `RulePanel` which are derived from `BasePanel`. Each of these panels contains an instance of `GraphScene`.

Here's the cleanup implementation:
1. Add a cleanup method in the `BasePanel` class.
2. Call this cleanup method for each panel in the MainWindow's closeEvent.

Firslty, I added a `shutdown` method to the `GraphScene` class. Then, added a corresponding method in the `BasePanel` class that calls `GraphScene.shutdown()`
Next, I ensured each panel subclassing `BasePanel` class provides its own shutdown method. 
Finally, I modified the `closeEvent` of the `MainWindow` class to shutdown on each panel before closing. 

This method ensures that each `GraphScene` is properly cleaned up before the main window closes. 