### PR TITLE
Remove entrypoint name collision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ packages = [
     "zxlive"
 ]
 
-[project.scripts]
-zxlive = "zxlive.app:main"
-
 [project.gui-scripts]
 zxlive = "zxlive.app:main"
 


### PR DESCRIPTION
When defining entry points to a python application using the project.scripts and the project.gui-scripts, the names should be unique. Otherwise it is ambigious which is to be called when exectuing in the commandline. Which causes issues for packaging. See also https://packaging.python.org/en/latest/specifications/entry-points/#entry-points

In the documentation we can only see that the only difference between scripts and gui-scripts is on windows whether a terminal is launched with the application. Since this is a gui-application I opt for using gui-script, which does not provide the program with the standard io pipes. This is indeed a choice, and the other choice is equally valid.