### PR TITLE
Bring parameters to Copy/paste

### DIFF
--- a/zxlive/base_panel.py
+++ b/zxlive/base_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from typing import Iterator, Optional, Sequence, Type
 
@@ -110,9 +111,10 @@ class BasePanel(QWidget):
         self.graph_scene.clearSelection()
 
     def copy_selection(self) -> GraphT:
-        selection = list(self.graph_scene.selected_vertices)
-        copied_graph = self.graph.subgraph_from_vertices(selection)
-        # Mypy issue: https://github.com/python/mypy/issues/11673
+        selection = set(self.graph_scene.selected_vertices)
+        copied_graph = copy.deepcopy(self.graph)
+        rem_vertices = [v for v in copied_graph.vertices() if v not in selection]
+        copied_graph.remove_vertices(rem_vertices)
         assert isinstance(copied_graph, GraphT)  # type: ignore
         return copied_graph
 


### PR DESCRIPTION
Aim to fix https://github.com/zxcalc/zxlive/issues/363

## What was added and modified:

### Files

1. base_panel.py
2. editor_base_panel.py
3. common.py

### Functionalities

- Use deepcopy to preserve full graph-internal metadata before pruning to the selected vertices.
- Added graph_variable_names (graph) so variable handling is based on variables actually used in phases of the copied/pasted fragment.
- Variable type (Boolean vs Parametric) is also propagated for relevant variables.
- Prevent a side-effects of duplicating variable rows by doing a manual name tracking (self._names) and early return in add_item.


https://github.com/user-attachments/assets/dd7795de-fee2-4a7e-8664-6adf966ad129




