### PR TITLE
fix TikZ proof export layout: use relative coordinates and align equal signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # ZXLive changelog
 
 
+## Unreleased
+
+- Fixed TikZ proof export so that graphs offset from the origin are normalised, equal signs are vertically centred between adjacent steps, and row wrapping works correctly (#198).
+
+
 ## v1.0.0
 This is the first version where changes were tracked. This version 1.0.0 release brings with it many new features, including:
 

--- a/test/test_tikz.py
+++ b/test/test_tikz.py
@@ -1,11 +1,224 @@
 """Tests for TikZ proof export (zxlive.tikz)."""
 
+import re
+from typing import Iterator
+
+import pytest
+from PySide6.QtCore import QSettings
 from pyzx.utils import VertexType
 from pytestqt.qtbot import QtBot
 
-from zxlive.common import new_graph
+from zxlive.common import GraphT, new_graph
 from zxlive.proof import ProofModel, Rewrite
 from zxlive.tikz import _escape_tex, proof_to_tikz
+
+
+# Layout knobs that the expected coordinates below depend on.
+_TIKZ_LAYOUT: dict[str, float] = {
+    "tikz/layout/hspace": 2.0,
+    "tikz/layout/vspace": 2.0,
+    "tikz/layout/max-width": 10.0,
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_tikz_settings() -> Iterator[None]:
+    """Pin TikZ layout settings on the per-test QSettings path."""
+    settings = QSettings("zxlive", "zxlive")
+    saved: dict[str, object] = {
+        key: settings.value(key) if settings.contains(key) else None
+        for key in _TIKZ_LAYOUT
+    }
+    for key, layout_value in _TIKZ_LAYOUT.items():
+        settings.setValue(key, layout_value)
+    # sync() so other QSettings instances (e.g. those created inside
+    # proof_to_tikz()) observe the overrides.
+    settings.sync()
+    try:
+        yield
+    finally:
+        for key, saved_value in saved.items():
+            if saved_value is None:
+                settings.remove(key)
+            else:
+                settings.setValue(key, saved_value)
+        settings.sync()
+
+
+def _make_graph(qubit_min: float, qubit_max: float, row_max: float = 1.0) -> GraphT:
+    """Build a minimal graph spanning the given qubit and row ranges."""
+    g = new_graph()
+    g.add_vertex(VertexType.Z, qubit=qubit_min, row=0)
+    g.add_vertex(VertexType.Z, qubit=qubit_max, row=row_max)
+    return g
+
+
+# Regex for the equal-sign nodes emitted by proof_to_tikz.
+# Captures the y-coordinate as group 1.
+_EQ_NODE_RE = re.compile(
+    r"\\node \[style=none\] \(\d+\) at \([^,]+, (-?[\d.]+)\)"
+)
+
+# Regex for Z-spider vertex nodes. Captures (x, y) as groups 1 and 2.
+_Z_NODE_RE = re.compile(
+    r"\\node \[style=Z dot\] \(\d+\) at \((-?[\d.]+), (-?[\d.]+)\)"
+)
+
+
+def test_eq_sign_uses_max_height(qtbot: QtBot) -> None:
+    """Equal sign between steps is centred using the taller of the two graphs."""
+    tall = _make_graph(0, 4)   # height 4
+    short = _make_graph(0, 1)  # height 1
+
+    proof = ProofModel(tall)
+    proof.add_rewrite(Rewrite("r", "r", short))
+
+    tikz = proof_to_tikz(proof)
+    eq_nodes = _EQ_NODE_RE.findall(tikz)
+    assert len(eq_nodes) == 1
+
+    y = float(eq_nodes[0])
+    # yoffset starts at -10, so y = -(-10) - eq_height/2 = 10 - eq_height/2.
+    # With the fix, eq_height = max(4, 1) = 4, giving y = 8.0.
+    # Without the fix, eq_height = 1, giving y = 9.5.
+    assert y == 8.0
+
+
+def test_eq_sign_symmetric_heights(qtbot: QtBot) -> None:
+    """When adjacent graphs have equal heights, eq_height equals that height."""
+    g1 = _make_graph(0, 3)
+    g2 = _make_graph(0, 3)
+
+    proof = ProofModel(g1)
+    proof.add_rewrite(Rewrite("r", "r", g2))
+
+    tikz = proof_to_tikz(proof)
+    eq_nodes = _EQ_NODE_RE.findall(tikz)
+    assert len(eq_nodes) == 1
+
+    y = float(eq_nodes[0])
+    # eq_height = max(3, 3) = 3, so y = 10 - 1.5 = 8.5.
+    assert y == 8.5
+
+
+def test_eq_sign_short_then_tall(qtbot: QtBot) -> None:
+    """Equal sign is still correct when the second graph is taller."""
+    short = _make_graph(0, 1)  # height 1
+    tall = _make_graph(0, 5)   # height 5
+
+    proof = ProofModel(short)
+    proof.add_rewrite(Rewrite("r", "r", tall))
+
+    tikz = proof_to_tikz(proof)
+    eq_nodes = _EQ_NODE_RE.findall(tikz)
+    assert len(eq_nodes) == 1
+
+    y = float(eq_nodes[0])
+    # eq_height = max(1, 5) = 5, so y = 10 - 2.5 = 7.5.
+    assert y == 7.5
+
+
+def test_qubit_offset_is_normalised(qtbot: QtBot) -> None:
+    """Graphs drawn away from the origin are translated to start at qubit 0."""
+    g = _make_graph(5, 8)  # height 3, but offset to qubit 5-8
+
+    proof = ProofModel(g)
+    tikz = proof_to_tikz(proof)
+
+    ys = [float(y) for _, y in _Z_NODE_RE.findall(tikz)]
+    # After normalisation the qubit span should be 0..3, mapped to
+    # y-coordinates -yoffset .. -(yoffset+3) = 10 .. 7.
+    assert min(ys) == 7.0
+    assert max(ys) == 10.0
+
+
+def test_offset_graphs_align_eq_sign(qtbot: QtBot) -> None:
+    """Equal sign aligns correctly even when graphs are offset from the origin."""
+    # Both graphs have height 2 but sit at different qubit offsets.
+    g1 = _make_graph(10, 12)  # height 2, offset at qubit 10
+    g2 = _make_graph(3, 5)    # height 2, offset at qubit 3
+
+    proof = ProofModel(g1)
+    proof.add_rewrite(Rewrite("r", "r", g2))
+
+    tikz = proof_to_tikz(proof)
+    eq_nodes = _EQ_NODE_RE.findall(tikz)
+    assert len(eq_nodes) == 1
+
+    y = float(eq_nodes[0])
+    # Both heights are 2 after normalisation, so eq_height = 2, y = 10 - 1.0 = 9.0.
+    assert y == 9.0
+
+
+def test_eq_sign_after_wrap_ignores_prev_height(qtbot: QtBot) -> None:
+    """After a row wrap, the equal sign is centred using only the current graph."""
+    # Force every graph to wrap onto a new row.
+    settings = QSettings("zxlive", "zxlive")
+    settings.setValue("tikz/layout/max-width", 0.0)
+    settings.sync()
+
+    tall = _make_graph(0, 4)   # height 4
+    short = _make_graph(0, 1)  # height 1
+
+    proof = ProofModel(tall)
+    proof.add_rewrite(Rewrite("r", "r", short))
+
+    tikz = proof_to_tikz(proof)
+    eq_nodes = _EQ_NODE_RE.findall(tikz)
+    assert len(eq_nodes) == 1
+
+    y = float(eq_nodes[0])
+    # After the first graph wraps, yoffset becomes -10 + 4 + 2 = -4, so the eq
+    # sign is at y = 4 - eq_height/2. Since the previous graph is on a different
+    # row, eq_height should be only the current graph's height (1), giving 3.5.
+    # If prev_height leaked across the wrap, eq_height would be max(4, 1) = 4,
+    # giving 2.0.
+    assert y == 3.5
+
+
+def test_wrap_before_emitting_overflow_graph(qtbot: QtBot) -> None:
+    """A graph that would extend past max-width is wrapped before being rendered."""
+    # max-width=10, hspace=2. After graph 1 (width 8) at xoffset=-10 and graph 2
+    # (width 8) at xoffset=0, xoffset reaches 10. Graph 3 (width 8) at that
+    # xoffset would extend to x=18 > 10, so it must wrap before being rendered.
+    g1 = _make_graph(0, 1, row_max=8.0)
+    g2 = _make_graph(0, 1, row_max=8.0)
+    g3 = _make_graph(0, 1, row_max=8.0)
+
+    proof = ProofModel(g1)
+    proof.add_rewrite(Rewrite("r", "r", g2))
+    proof.add_rewrite(Rewrite("r", "r", g3))
+
+    tikz = proof_to_tikz(proof)
+    xs = [float(x) for x, _ in _Z_NODE_RE.findall(tikz)]
+    # No vertex may extend past max-width.
+    assert max(xs) <= 10.0
+
+
+def test_wrap_advances_by_row_max_height(qtbot: QtBot) -> None:
+    """Wrapping advances yoffset by the tallest graph in the row, not the last."""
+    # max-width=10, hspace=2, vspace=2. Row 1: graph 1 (width 8, height 5) at
+    # xoffset=-10, then graph 2 (width 8, height 1) at xoffset=0; xoffset
+    # reaches 10. Graph 3 (width 8) wraps. row_max_height = max(5, 1) = 5, so
+    # row-2 yoffset = -10 + 5 + 2 = -3, and the eq sign for graph 2 -> graph 3
+    # sits at y = 3 - height(graph 3)/2 = 3 - 2 = 1.0. If yoffset were advanced
+    # by graph 2's height (1) instead, the eq sign would land at y = 5 and row
+    # 2 would overlap row 1 (whose y range is [5, 10]).
+    g1 = _make_graph(0, 5, row_max=8.0)
+    g2 = _make_graph(0, 1, row_max=8.0)
+    g3 = _make_graph(0, 4, row_max=8.0)
+
+    proof = ProofModel(g1)
+    proof.add_rewrite(Rewrite("r", "r", g2))
+    proof.add_rewrite(Rewrite("r", "r", g3))
+
+    tikz = proof_to_tikz(proof)
+    eq_ys = [float(y) for y in _EQ_NODE_RE.findall(tikz)]
+    assert len(eq_ys) == 2
+    # Row-1 eq sign: y = 10 - max(5, 1)/2 = 7.5.
+    assert eq_ys[0] == 7.5
+    # Row-2 eq sign: y = 3 - 4/2 = 1.0.
+    assert eq_ys[1] == 1.0
 
 
 def test_escape_tex_passes_safe_chars_through() -> None:
@@ -27,12 +240,8 @@ def test_escape_tex_escapes_special_chars() -> None:
 
 def test_proof_to_tikz_escapes_rule_name(qtbot: QtBot) -> None:
     """A rule name with TeX-special characters does not break the eq label."""
-    g1 = new_graph()
-    g1.add_vertex(VertexType.Z, qubit=0, row=0)
-    g1.add_vertex(VertexType.Z, qubit=1, row=1)
-    g2 = new_graph()
-    g2.add_vertex(VertexType.Z, qubit=0, row=0)
-    g2.add_vertex(VertexType.Z, qubit=1, row=1)
+    g1 = _make_graph(0, 1)
+    g2 = _make_graph(0, 1)
 
     # An adversarial rule name that would otherwise close the \mathit{...} block.
     proof = ProofModel(g1)
@@ -42,3 +251,23 @@ def test_proof_to_tikz_escapes_rule_name(qtbot: QtBot) -> None:
     # The raw "}{" must not appear in the output unescaped.
     assert "evil}{x" not in tikz
     assert r"evil\}\{x" in tikz
+
+
+def test_proof_to_tikz_handles_empty_graph(qtbot: QtBot) -> None:
+    """Exporting a proof whose initial graph has no vertices does not crash."""
+    proof = ProofModel(new_graph())
+    # No vertices means no Z nodes and no eq sign; TIKZ_BASE wraps an empty body.
+    tikz = proof_to_tikz(proof)
+    assert _EQ_NODE_RE.findall(tikz) == []
+    assert _Z_NODE_RE.findall(tikz) == []
+
+
+def test_proof_to_tikz_handles_empty_step(qtbot: QtBot) -> None:
+    """An empty step in a non-empty proof is handled without crashing."""
+    g = _make_graph(0, 1)
+    proof = ProofModel(g)
+    proof.add_rewrite(Rewrite("r", "r", new_graph()))
+
+    tikz = proof_to_tikz(proof)
+    # The eq sign is still emitted for the rewrite.
+    assert len(_EQ_NODE_RE.findall(tikz)) == 1

--- a/zxlive/tikz.py
+++ b/zxlive/tikz.py
@@ -2,7 +2,7 @@ from PySide6.QtCore import QSettings
 from pyzx.tikz import TIKZ_BASE, _to_tikz
 
 from .common import GraphT, get_settings_value
-from zxlive.proof import ProofModel
+from zxlive.proof import ProofModel, Rewrite
 
 
 def _escape_tex(s: str) -> str:
@@ -22,65 +22,88 @@ def _escape_tex(s: str) -> str:
     return "".join(out)
 
 
+def _normalise_graph(g: GraphT) -> tuple[GraphT, int, float, float]:
+    """Translate ``g`` so its vertices start at the origin.
+
+    Returns the translated graph, the maximum vertex ID, width and height.
+    Empty graphs are returned untouched with max vertex ID -1 and zero width
+    and height.
+    """
+    vertex_ids = list(g.vertices())
+    if not vertex_ids:
+        return g, -1, 0.0, 0.0
+    rows = [g.row(v) for v in vertex_ids]
+    qubits = [g.qubit(v) for v in vertex_ids]
+    min_x, max_x = min(rows), max(rows)
+    min_y, max_y = min(qubits), max(qubits)
+    g_t = g.translate(-min_x, -min_y)
+    assert isinstance(g_t, GraphT)
+    return g_t, max(vertex_ids), max_x - min_x, max_y - min_y
+
+
+def _eq_node(settings: QSettings, rewrite: Rewrite, idoffset: int, xoffset: float,
+             yoffset: float, hspace: float, eq_height: float) -> str:
+    """Format the equal-sign node that sits between two adjacent proof graphs."""
+    key = f"tikz/names/{rewrite.rule}"
+    name = settings.value(key) if settings.contains(key) else rewrite.rule
+    # Escape TeX-special characters since the name is interpolated into LaTeX.
+    name = _escape_tex(str(name))
+    return (f"\\node [style=none] ({idoffset}) at "
+            f"({xoffset - hspace/2:.2f}, {-yoffset - eq_height/2:.2f}) "
+            f"{{$\\mathrel{{\\mathop{{=}}\\limits^{{\\mathit{{{name}}}}}}}$}};")
+
+
 def proof_to_tikz(proof: ProofModel) -> str:
     settings = QSettings("zxlive", "zxlive")
     vspace = get_settings_value("tikz/layout/vspace", float, settings=settings)
     hspace = get_settings_value("tikz/layout/hspace", float, settings=settings)
     max_width = get_settings_value("tikz/layout/max-width", float, settings=settings)
-    draw_scalar = False
 
     xoffset = -max_width
-    yoffset = -10
+    yoffset = -10.0
     idoffset = 0
     total_verts, total_edges = [], []
-    for i, g in enumerate(proof.graphs()):
-        # Compute graph dimensions
-        width = max(g.row(v) for v in g.vertices()) - min(g.row(v) for v in g.vertices())
-        height = max(g.qubit(v) for v in g.vertices()) - min(g.qubit(v) for v in g.vertices())
+    prev_height = 0.0
+    row_max_height = 0.0
+    for i, g_in in enumerate(proof.graphs()):
+        g, max_vertex_id, width, height = _normalise_graph(g_in)
 
-        # Translate graph so that the first vertex starts at 0
-        min_x = min(g.row(v) for v in g.vertices())
-        g_t = g.translate(-min_x, 0)
-        assert isinstance(g_t, GraphT)
-        g = g_t
+        # Wrap before emitting the graph so it is never placed past max_width,
+        # and advance yoffset by the tallest graph in the row being closed (not
+        # just the last one) so the next row cannot overlap a taller neighbour.
+        wrapped = False
+        if i > 0 and xoffset + width > max_width:
+            xoffset = -max_width
+            yoffset += row_max_height + vspace
+            row_max_height = 0.0
+            wrapped = True
 
         if i > 0:
-            rewrite = proof.steps[i - 1]
-            # Try to look up name in settings
-            name = settings.value(f"tikz/names/{rewrite.rule}") if settings.contains(f"tikz/names/{rewrite.rule}") else rewrite.rule
-            # Escape TeX-special characters since the name is interpolated into LaTeX.
-            name = _escape_tex(str(name))
-            eq = f"\\node [style=none] ({idoffset}) at ({xoffset - hspace/2:.2f}, {-yoffset - height/2:.2f}) {{$\\mathrel{{\\mathop{{=}}\\limits^{{\\mathit{{{name}}}}}}}$}};"
-            total_verts.append(eq)
+            # Use the max of prev_height and current height to centre the equal
+            # sign. If wrapped to a new row, ignore prev_height since it is on
+            # a different row.
+            eq_height = height if wrapped else max(prev_height, height)
+            total_verts.append(_eq_node(settings, proof.steps[i - 1], idoffset,
+                                        xoffset, yoffset, hspace, eq_height))
             idoffset += 1
 
-        verts, edges = _to_tikz(g, draw_scalar, xoffset, yoffset, idoffset)
+        verts, edges = _to_tikz(g, False, xoffset, yoffset, idoffset)
         total_verts.extend(verts)
         total_edges.extend(edges)
 
-        if xoffset + hspace > max_width:
-            xoffset = -max_width
-            yoffset += height + vspace
-        else:
-            xoffset += width + hspace
+        row_max_height = max(row_max_height, height)
+        xoffset += width + hspace
 
-        max_index = max(g.vertices()) + 2 * g.num_inputs() + 2
-        idoffset += max_index
+        if max_vertex_id >= 0:
+            idoffset += max_vertex_id + 2 * g.num_inputs() + 2
+        prev_height = height
 
     return TIKZ_BASE.format(vertices="\n".join(total_verts), edges="\n".join(total_edges))
 
 
 def graph_to_tikz(graph: GraphT) -> str:
     """Convert a single graph to TikZ format."""
-    vertices = list(graph.vertices())
-    if vertices:
-        # Translate graph so that the leftmost vertex starts at 0.
-        min_x = min(graph.row(v) for v in vertices)
-        g_t = graph.translate(-min_x, 0)
-        assert isinstance(g_t, GraphT)
-    else:
-        g_t = graph
-
+    g_t, _, _, _ = _normalise_graph(graph)
     verts, edges = _to_tikz(g_t, draw_scalar=False, xoffset=0, yoffset=0, idoffset=0)
     return TIKZ_BASE.format(vertices="\n".join(verts), edges="\n".join(edges))
 


### PR DESCRIPTION
Relates to #198.