### PR TITLE
Make saving rewrite in rules folder the default

### DIFF
--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
@@ -14,6 +15,7 @@ from pyzx import Circuit, extract_circuit
 from pyzx.utils import VertexType
 
 from .common import GraphT, VT
+from .settings import get_settings_value
 from .custom_rule import CustomRule, check_rule
 from .proof import ProofModel
 
@@ -280,7 +282,9 @@ def save_proof_dialog(proof_model: ProofModel, parent: QWidget) -> Optional[tupl
 
 
 def save_rule_dialog(rule: CustomRule, parent: QWidget, filename: str = "") -> Optional[tuple[str, FileFormat]]:
-    return _save_rule_or_proof_dialog(rule.to_json(), parent, FileFormat.ZXRule.filter, filename)
+    rules_folder = get_settings_value("path/custom-rules", str)
+    default_path = os.path.join(rules_folder, filename) if filename else rules_folder
+    return _save_rule_or_proof_dialog(rule.to_json(), parent, FileFormat.ZXRule.filter, default_path)
 
 
 def export_proof_dialog(parent: QWidget) -> Optional[str]:

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -283,7 +283,12 @@ def save_proof_dialog(proof_model: ProofModel, parent: QWidget) -> Optional[tupl
 
 def save_rule_dialog(rule: CustomRule, parent: QWidget, filename: str = "") -> Optional[tuple[str, FileFormat]]:
     rules_folder = get_settings_value("path/custom-rules", str)
-    default_path = os.path.join(rules_folder, filename) if filename else rules_folder
+    if filename:
+        default_path = os.path.join(rules_folder, filename)
+    elif rule.name:
+        default_path = os.path.join(rules_folder, rule.name + ".zxr")
+    else:
+        default_path = rules_folder
     return _save_rule_or_proof_dialog(rule.to_json(), parent, FileFormat.ZXRule.filter, default_path)
 
 


### PR DESCRIPTION
Fixes #486 
When saving a rewrite rule, the file explorer now opens directly in the custom rules folder (configured in Settings → General → Custom rules path) instead of the system default directory.

The setting and the parameter to pass it through already existed : ` _save_rule_or_proof_dialog` already accepted a dir argument, and path/custom-rules was already in settings. This just wires them together in save_rule_dialog.

