### PR TITLE
escape TeX-special characters in TikZ proof rule names

### DIFF
--- a/test/test_tikz.py
+++ b/test/test_tikz.py
@@ -1,0 +1,44 @@
+"""Tests for TikZ proof export (zxlive.tikz)."""
+
+from pyzx.utils import VertexType
+from pytestqt.qtbot import QtBot
+
+from zxlive.common import new_graph
+from zxlive.proof import ProofModel, Rewrite
+from zxlive.tikz import _escape_tex, proof_to_tikz
+
+
+def test_escape_tex_passes_safe_chars_through() -> None:
+    assert _escape_tex("fuse spiders") == "fuse spiders"
+    assert _escape_tex("ABC123") == "ABC123"
+
+
+def test_escape_tex_escapes_special_chars() -> None:
+    assert _escape_tex("a%b") == r"a\%b"
+    assert _escape_tex("a#b") == r"a\#b"
+    assert _escape_tex("a&b") == r"a\&b"
+    assert _escape_tex("a$b") == r"a\$b"
+    assert _escape_tex("a_b") == r"a\_b"
+    assert _escape_tex("a{b}c") == r"a\{b\}c"
+    assert _escape_tex(r"a\b") == r"a\backslash{}b"
+    assert _escape_tex("a^b") == r"a\string^b"
+    assert _escape_tex("a~b") == r"a\string~b"
+
+
+def test_proof_to_tikz_escapes_rule_name(qtbot: QtBot) -> None:
+    """A rule name with TeX-special characters does not break the eq label."""
+    g1 = new_graph()
+    g1.add_vertex(VertexType.Z, qubit=0, row=0)
+    g1.add_vertex(VertexType.Z, qubit=1, row=1)
+    g2 = new_graph()
+    g2.add_vertex(VertexType.Z, qubit=0, row=0)
+    g2.add_vertex(VertexType.Z, qubit=1, row=1)
+
+    # An adversarial rule name that would otherwise close the \mathit{...} block.
+    proof = ProofModel(g1)
+    proof.add_rewrite(Rewrite("evil}{x", "evil}{x", g2))
+
+    tikz = proof_to_tikz(proof)
+    # The raw "}{" must not appear in the output unescaped.
+    assert "evil}{x" not in tikz
+    assert r"evil\}\{x" in tikz

--- a/zxlive/tikz.py
+++ b/zxlive/tikz.py
@@ -5,6 +5,23 @@ from .common import GraphT, get_settings_value
 from zxlive.proof import ProofModel
 
 
+def _escape_tex(s: str) -> str:
+    """Escape characters that would otherwise break LaTeX parsing."""
+    out = []
+    for ch in s:
+        if ch == "\\":
+            out.append(r"\backslash{}")
+        elif ch in "{}%#&$_":
+            out.append("\\" + ch)
+        elif ch == "^":
+            out.append(r"\string^")
+        elif ch == "~":
+            out.append(r"\string~")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 def proof_to_tikz(proof: ProofModel) -> str:
     settings = QSettings("zxlive", "zxlive")
     vspace = get_settings_value("tikz/layout/vspace", float, settings=settings)
@@ -31,6 +48,8 @@ def proof_to_tikz(proof: ProofModel) -> str:
             rewrite = proof.steps[i - 1]
             # Try to look up name in settings
             name = settings.value(f"tikz/names/{rewrite.rule}") if settings.contains(f"tikz/names/{rewrite.rule}") else rewrite.rule
+            # Escape TeX-special characters since the name is interpolated into LaTeX.
+            name = _escape_tex(str(name))
             eq = f"\\node [style=none] ({idoffset}) at ({xoffset - hspace/2:.2f}, {-yoffset - height/2:.2f}) {{$\\mathrel{{\\mathop{{=}}\\limits^{{\\mathit{{{name}}}}}}}$}};"
             total_verts.append(eq)
             idoffset += 1


### PR DESCRIPTION
Fixes #492.