### PR TITLE
isolate `QSettings` in tests to avoid changing user config

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,80 @@
+"""Pytest fixtures and hooks shared across the test suite.
+
+QSettings is redirected at conftest import time (so zxlive's import-time
+writes are sandboxed) and again per-test by an autouse fixture (so tests
+that build fresh QSettings don't leak state to each other). Module-level
+QSettings instances created during import keep using the session-scoped
+path for their whole lifetime.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from PySide6.QtCore import QSettings
+
+
+def _probe_default_path(fmt: QSettings.Format) -> str:
+    """Probe Qt's default UserScope base path for ``fmt`` via a throwaway QSettings.
+
+    Accepts the ``<base>/<org>/<app>.ext`` and ``<base>/<app>.ext`` layouts;
+    raises on anything else rather than silently restoring a wrong path.
+    """
+    probe_org = "zxlive-conftest-probe-org"
+    probe_app = "zxlive-conftest-probe-app"
+    probe = QSettings(fmt, QSettings.Scope.UserScope, probe_org, probe_app)
+    probe_path = Path(probe.fileName())
+
+    if probe_path.stem == probe_app:
+        if probe_path.parent.name == probe_org:
+            return str(probe_path.parent.parent)
+        return str(probe_path.parent)
+
+    raise RuntimeError(
+        f"Unable to derive QSettings base path for {fmt!r} from "
+        f"{probe.fileName()!r}"
+    )
+
+
+# PySide6's ``QSettings(org, app)`` ignores ``setDefaultFormat`` and uses
+# ``NativeFormat``, so redirect both formats to cover either choice.
+_ORIGINAL_FORMAT = QSettings.defaultFormat()
+_ORIGINAL_NATIVE_PATH = _probe_default_path(QSettings.Format.NativeFormat)
+_ORIGINAL_INI_PATH = _probe_default_path(QSettings.Format.IniFormat)
+
+_QSETTINGS_TMPDIR = tempfile.TemporaryDirectory(prefix="zxlive-test-qsettings-")
+
+
+def _set_qsettings_paths(path: str) -> None:
+    """Point both QSettings formats at ``path`` for UserScope."""
+    QSettings.setPath(QSettings.Format.NativeFormat, QSettings.Scope.UserScope,
+                      path)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
+                      path)
+
+
+QSettings.setDefaultFormat(QSettings.Format.IniFormat)
+_set_qsettings_paths(_QSETTINGS_TMPDIR.name)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_qsettings(tmp_path: Path) -> Iterator[None]:
+    """Redirect new QSettings instances to a per-test subdirectory."""
+    _set_qsettings_paths(str(tmp_path))
+    try:
+        yield
+    finally:
+        _set_qsettings_paths(_QSETTINGS_TMPDIR.name)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore the original QSettings state and remove the temp directory."""
+    QSettings.setDefaultFormat(_ORIGINAL_FORMAT)
+    QSettings.setPath(QSettings.Format.NativeFormat, QSettings.Scope.UserScope,
+                      _ORIGINAL_NATIVE_PATH)
+    QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope,
+                      _ORIGINAL_INI_PATH)
+    _QSETTINGS_TMPDIR.cleanup()

--- a/test/test_update_checker.py
+++ b/test/test_update_checker.py
@@ -25,19 +25,15 @@ def test_version_comparison() -> None:
 
 def test_should_check_for_updates_no_previous_check() -> None:
     """Test that update check is needed when there's no previous check."""
-    settings = QSettings("zxlive-test", "zxlive-test")
-    settings.clear()  # Clear any existing settings
+    settings = QSettings("zxlive", "zxlive")
 
     checker = UpdateChecker("0.3.1", settings)
     assert checker.should_check_for_updates()
 
-    settings.clear()
-
 
 def test_should_check_for_updates_recent_check() -> None:
     """Test that update check is not needed when recently checked."""
-    settings = QSettings("zxlive-test", "zxlive-test")
-    settings.clear()
+    settings = QSettings("zxlive", "zxlive")
 
     # Set last check to now
     from zxlive.common import set_settings_value
@@ -46,13 +42,10 @@ def test_should_check_for_updates_recent_check() -> None:
     checker = UpdateChecker("0.3.1", settings)
     assert not checker.should_check_for_updates()
 
-    settings.clear()
-
 
 def test_should_check_for_updates_old_check() -> None:
     """Test that update check is needed when last check was long ago."""
-    settings = QSettings("zxlive-test", "zxlive-test")
-    settings.clear()
+    settings = QSettings("zxlive", "zxlive")
 
     # Set last check to 2 days ago
     from zxlive.common import set_settings_value
@@ -61,8 +54,6 @@ def test_should_check_for_updates_old_check() -> None:
 
     checker = UpdateChecker("0.3.1", settings)
     assert checker.should_check_for_updates()
-
-    settings.clear()
 
 
 def test_update_checker_initialization() -> None:


### PR DESCRIPTION
Add an autouse `conftest.py` fixture that redirects `QSettings` to a per-test temp directory, protecting all current and future tests (including those that touch settings indirectly via `MainWindow`). 

Also drop the now-redundant `zxlive-test` org name in `test_update_checker.py` (which was the only test previously to attempt to prevent test config from clobbering user config), so the entire test suite uses one isolation mechanism.

Fixes #494.