### PR TITLE
add feature to export proof steps as TikZ series

### DIFF
--- a/test/test_mainwindow.py
+++ b/test/test_mainwindow.py
@@ -80,25 +80,56 @@ def test_start_derivation(app: MainWindow, qtbot: QtBot) -> None:
     assert app.active_panel is not None
     assert isinstance(app.active_panel, GraphEditPanel)
     assert not app.export_tikz_proof.isEnabled()
+    assert not app.export_tikz_series.isEnabled()
 
     # Start a derivation. Export to tikz is enabled.
     qtbot.mouseClick(app.active_panel.start_derivation, QtCore.Qt.MouseButton.LeftButton)
     assert app.tab_widget.count() == 2
     assert isinstance(app.active_panel, ProofPanel)
     assert app.export_tikz_proof.isEnabled()
+    assert app.export_tikz_series.isEnabled()
 
     # Switch to the demo graph tab. Export to tikz is disabled.
     app.tab_widget.setCurrentIndex(0)
     assert not app.export_tikz_proof.isEnabled()
+    assert not app.export_tikz_series.isEnabled()
 
     # Switch back to the proof tab. Export to tikz is enabled.
     app.tab_widget.setCurrentIndex(1)
     assert app.export_tikz_proof.isEnabled()
+    assert app.export_tikz_series.isEnabled()
 
     # Close the proof tab. Export to tikz is disabled.
     app.close_action.trigger()
     assert app.tab_widget.count() == 1
     assert not app.export_tikz_proof.isEnabled()
+    assert not app.export_tikz_series.isEnabled()
+
+
+def test_export_tikz_series(app: MainWindow, qtbot: QtBot, tmp_path: Path,
+                            monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exporting proof steps writes one .tikz file per step into the chosen directory."""
+    from PySide6.QtWidgets import QFileDialog
+
+    assert isinstance(app.active_panel, GraphEditPanel)
+    qtbot.mouseClick(app.active_panel.start_derivation, QtCore.Qt.MouseButton.LeftButton)
+    assert isinstance(app.active_panel, ProofPanel)
+
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: str(tmp_path))
+    assert app.handle_export_tikz_series_action()
+
+    files = sorted(p.name for p in tmp_path.iterdir())
+    num_steps = len(list(app.active_panel.proof_model.graphs()))
+    assert len(files) == num_steps
+    # Filenames have a zero-padded numeric prefix (minimum 3 digits) and a safe step name.
+    padding_width = max(3, len(str(max(num_steps - 1, 0))))
+    assert files[0] == f"{0:0{padding_width}d}_START.tikz"
+    for i, filename in enumerate(files):
+        prefix, _, rest = filename.partition("_")
+        assert prefix == f"{i:0{padding_width}d}"
+        assert rest.endswith(".tikz")
+        stem = rest[:-len(".tikz")]
+        assert all(c.isalnum() or c in "._-" for c in stem)
 
 
 def test_settings_dialog(app: MainWindow) -> None:

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -28,8 +28,8 @@ from PySide6.QtCore import (QByteArray, QEvent, QFile, QFileInfo, QIODevice,
                             Qt)
 from PySide6.QtGui import (QAction, QCloseEvent, QDesktopServices, QIcon,
                            QKeySequence, QMouseEvent, QShortcut)
-from PySide6.QtWidgets import (QApplication, QMainWindow, QMessageBox, QTabBar,
-                               QTabWidget, QVBoxLayout, QWidget)
+from PySide6.QtWidgets import (QApplication, QFileDialog, QMainWindow, QMessageBox,
+                               QTabBar, QTabWidget, QVBoxLayout, QWidget)
 from pyzx.drawing import graphs_to_gif
 from pyzx.graph.base import BaseGraph
 
@@ -51,7 +51,7 @@ from .rule_panel import RulePanel
 from .settings import display_setting
 from .settings_dialog import open_settings_dialog
 from .sfx import SFXEnum, load_sfx
-from .tikz import proof_to_tikz
+from .tikz import proof_to_tikz, proof_steps_to_tikz
 
 
 class MainWindow(QMainWindow):
@@ -132,6 +132,9 @@ class MainWindow(QMainWindow):
         self.export_gif_proof = self._new_action(
             "Export proof to gif", self.handle_export_gif_proof_action,
             None, "Exports the proof to gif")
+        self.export_tikz_series = self._new_action(
+            "Export proof steps to tikz files", self.handle_export_tikz_series_action,
+            None, "Exports each proof step to a separate tikz file")
         self.auto_save_action = self._new_action(
             "Auto Save", self.toggle_auto_save, None,
             "Automatically save the file after every edit"
@@ -149,6 +152,7 @@ class MainWindow(QMainWindow):
         file_menu.addAction(self.save_file)
         file_menu.addAction(self.save_as)
         file_menu.addAction(self.export_tikz_proof)
+        file_menu.addAction(self.export_tikz_series)
         file_menu.addAction(self.export_gif_proof)
         file_menu.addSeparator()
         file_menu.addAction(self.auto_save_action)
@@ -289,6 +293,7 @@ class MainWindow(QMainWindow):
 
         # Export to tikz and gif are enabled only if there is a proof in the active tab.
         self.export_tikz_proof.setEnabled(has_active_tab and isinstance(self.active_panel, ProofPanel))
+        self.export_tikz_series.setEnabled(has_active_tab and isinstance(self.active_panel, ProofPanel))
         self.export_gif_proof.setEnabled(has_active_tab and isinstance(self.active_panel, ProofPanel))
 
         # Paste is enabled only if there is something in the clipboard.
@@ -680,6 +685,30 @@ class MainWindow(QMainWindow):
             return False
         graphs: list[BaseGraph] = list(self.active_panel.proof_model.graphs())
         graphs_to_gif(graphs, path, 1000)  # 1000ms per frame
+        return True
+
+    def handle_export_tikz_series_action(self) -> bool:
+        """Export each proof step to a separate TikZ file in a chosen directory."""
+        assert isinstance(self.active_panel, ProofPanel)
+        directory = QFileDialog.getExistingDirectory(
+            self, "Select folder for TikZ files",
+            options=QFileDialog.Option.ShowDirsOnly)
+        if not directory:
+            return False
+
+        steps = proof_steps_to_tikz(self.active_panel.proof_model)
+        padding_width = max(3, len(str(max(len(steps) - 1, 0))))
+        for i, (name, tikz) in enumerate(steps):
+            # Create a safe filename from the step name.
+            safe_name = "".join(c if c.isalnum() or c in "._-" else "_" for c in name)
+            filename = f"{i:0{padding_width}d}_{safe_name}.tikz"
+            file_path = os.path.join(directory, filename)
+            try:
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(tikz)
+            except OSError as e:
+                show_error_msg("Export failed", f"Could not write to {file_path}: {e}", parent=self)
+                return False
         return True
 
     def cut_graph(self) -> None:

--- a/zxlive/tikz.py
+++ b/zxlive/tikz.py
@@ -49,3 +49,38 @@ def proof_to_tikz(proof: ProofModel) -> str:
         idoffset += max_index
 
     return TIKZ_BASE.format(vertices="\n".join(total_verts), edges="\n".join(total_edges))
+
+
+def graph_to_tikz(graph: GraphT) -> str:
+    """Convert a single graph to TikZ format."""
+    vertices = list(graph.vertices())
+    if vertices:
+        # Translate graph so that the leftmost vertex starts at 0.
+        min_x = min(graph.row(v) for v in vertices)
+        g_t = graph.translate(-min_x, 0)
+        assert isinstance(g_t, GraphT)
+    else:
+        g_t = graph
+
+    verts, edges = _to_tikz(g_t, draw_scalar=False, xoffset=0, yoffset=0, idoffset=0)
+    return TIKZ_BASE.format(vertices="\n".join(verts), edges="\n".join(edges))
+
+
+def proof_steps_to_tikz(proof: ProofModel) -> list[tuple[str, str]]:
+    """Convert each proof step to a separate TikZ string.
+
+    Returns a list of (step_name, tikz_string) tuples.
+    """
+    result = []
+    graphs = proof.graphs()
+
+    for i, g in enumerate(graphs):
+        if i == 0:
+            name = "START"
+        else:
+            name = proof.steps[i - 1].display_name
+
+        tikz = graph_to_tikz(g)
+        result.append((name, tikz))
+
+    return result


### PR DESCRIPTION
Fixes #203.

Adds a new File menu option "Export proof steps to tikz files" that exports each proof step to a separate TikZ file in a user-selected directory. Files are named with zero-padded step numbers and the step name (e.g., "000_START.tikz", "001_spider_fusion.tikz").

This would be useful for creating presentations or LaTeX documents where each proof step is shown separately.
