### PR TITLE
fix crash when reapplying a saved-as-lemma rewrite

### DIFF
--- a/test/test_mainwindow.py
+++ b/test/test_mainwindow.py
@@ -14,18 +14,23 @@
 # limitations under the License.
 
 
+import copy
 import pytest
 import os
 from pathlib import Path
+from typing import Optional
 from PySide6 import QtCore
 from pytestqt.qtbot import QtBot
 
+import pyzx
 from pyzx.utils import EdgeType, VertexType
 
+from zxlive.commands import AddRewriteStep
 from zxlive.dialogs import import_diagram_from_file
 from zxlive.common import GraphT, W_INPUT_OFFSET, new_graph
 from zxlive.edit_panel import GraphEditPanel
 from zxlive.mainwindow import MainWindow
+from zxlive.rewrite_action import RewriteActionTree, RewriteActionTreeModel
 from zxlive.pauliwebs_panel import PauliWebsPanel
 from zxlive.proof_panel import ProofPanel
 from zxlive.settings_dialog import SettingsDialog
@@ -190,6 +195,84 @@ def test_proof_as_lemma(app: MainWindow, qtbot: QtBot, tmp_path: Path, monkeypat
     app.proof_as_lemma()
     with open(expected, encoding="utf-8") as f:
         assert f.read() == "sentinel"
+
+
+def test_save_proof_as_lemma_then_reapply(
+    app: MainWindow, qtbot: QtBot, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Saving a proof as a lemma, going back to the start, and reapplying the
+    saved rule must not crash. Regression test for #482."""
+    import zxlive.mainwindow
+    import zxlive.rewrite_data
+
+    rules_dir = str(tmp_path)
+    monkeypatch.setattr(zxlive.mainwindow, "get_custom_rules_path", lambda: rules_dir)
+    monkeypatch.setattr(zxlive.rewrite_data, "get_custom_rules_path", lambda: rules_dir)
+    monkeypatch.setattr(zxlive.mainwindow, "get_lemma_name_and_description",
+                        lambda _parent: ("issue482", "regression"))
+
+    # A Z-Z chain so the lemma's lhs matches the start graph exactly.
+    g = new_graph()
+    inp = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+    z1 = g.add_vertex(VertexType.Z, qubit=0, row=1)
+    z2 = g.add_vertex(VertexType.Z, qubit=0, row=2)
+    out = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=3)
+    for s, t in ((inp, z1), (z1, z2), (z2, out)):
+        g.add_edge((s, t), EdgeType.SIMPLE)
+    g.set_inputs((inp,))
+    g.set_outputs((out,))
+    app.new_graph(g)
+
+    edit_panel = app.active_panel
+    assert isinstance(edit_panel, GraphEditPanel)
+    qtbot.mouseClick(edit_panel.start_derivation, QtCore.Qt.MouseButton.LeftButton)
+    proof_panel = app.active_panel
+    assert isinstance(proof_panel, ProofPanel)
+
+    fused = copy.deepcopy(proof_panel.graph)
+    pyzx.simplify.spider_simp(fused)
+    expected_vertex_count = len(list(fused.vertices()))
+    proof_panel.undo_stack.push(
+        AddRewriteStep(proof_panel.graph_view, fused, proof_panel.step_view, "fuse")
+    )
+    app.proof_as_lemma()
+    proof_panel.rewrites_panel.refresh_rewrites_model()
+    proof_panel.step_view.move_to_step(0)
+
+    rewrite_model = proof_panel.rewrites_panel.model()
+    assert isinstance(rewrite_model, RewriteActionTreeModel)
+    rule_node = _find_rewrite_node(rewrite_model.root_item, "issue482")
+    assert rule_node is not None
+
+    proof_panel.graph_scene.clearSelection()
+    for v in (z1, z2):
+        proof_panel.graph_scene.vertex_map[v].setSelected(True)
+
+    # Before #482's fix, this raised KeyError once the animation started.
+    rule_node.rewrite_action.enabled = True
+    rule_node.rewrite_action.do_rewrite(proof_panel)
+
+    # The rewrite is committed when anim_before finishes; wait for the graph
+    # to reflect the post-rewrite state instead of using a fixed delay.
+    qtbot.waitUntil(
+        lambda: len(list(proof_panel.graph.vertices())) == expected_vertex_count,
+        timeout=2000,
+    )
+
+    # Vertex IDs are reassigned each application, so check the structural
+    # shape: the saved lemma collapses the two Z spiders into a single one.
+    final = proof_panel.graph
+    internal = [v for v in final.vertices() if final.type(v) != VertexType.BOUNDARY]
+    assert len(internal) == 1 and final.type(internal[0]) == VertexType.Z
+
+
+def _find_rewrite_node(node: RewriteActionTree, name: str) -> Optional[RewriteActionTree]:
+    if node.is_rewrite and node.rewrite_action.name == name:
+        return node
+    for child in node.child_items:
+        if (found := _find_rewrite_node(child, name)) is not None:
+            return found
+    return None
 
 
 def test_auto_arrange(app: MainWindow) -> None:

--- a/test/test_vitem.py
+++ b/test/test_vitem.py
@@ -8,12 +8,15 @@ or fractions) shouldn't overlap with the node body.
 from fractions import Fraction
 
 import pytest
+from PySide6.QtCore import QAbstractAnimation, QPointF
 from pyzx.utils import VertexType
 from pytestqt.qtbot import QtBot
 
+from zxlive.eitem import EItem, EItemAnimation
 from zxlive.graphscene import GraphScene
 from zxlive.common import SCALE, new_graph
 from zxlive.rule_panel import RulePanel
+from zxlive.vitem import VItem, VItemAnimation
 
 def test_dummy_label_position(qtbot: QtBot) -> None:
     """Test that dummy labels sit cleanly above the node without overlapping.
@@ -176,3 +179,50 @@ def test_update_io_labels_overwrites_stale_labels(qtbot: QtBot) -> None:
     assert scene.vertex_map[v_in1].phase_item.toPlainText() == "in-1"
     assert scene.vertex_map[v_out0].phase_item.toPlainText() == "out-0"
     assert scene.vertex_map[v_out1].phase_item.toPlainText() == "out-1"
+
+
+def test_vitem_animation_handles_missing_vertex(qtbot: QtBot) -> None:
+    """A VItemAnimation whose target id is absent from ``vertex_map`` must
+    no-op rather than raise. Regression test for #482."""
+    g = new_graph()
+    v = g.add_vertex(VertexType.Z, qubit=0, row=0)
+    scene = GraphScene()
+    scene.set_graph(g)
+
+    anim = VItemAnimation(v, VItem.Properties.Position, scene, refresh=True)
+    anim.setStartValue(QPointF(0, 0))
+    anim.setEndValue(QPointF(SCALE, SCALE))
+    anim.setDuration(50)
+    del scene.vertex_map[v]
+
+    assert anim.it is None
+    anim._on_state_changed(QAbstractAnimation.State.Running)
+    anim._on_state_changed(QAbstractAnimation.State.Stopped)
+    anim.updateCurrentValue(QPointF(SCALE / 2, SCALE / 2))
+    with qtbot.waitSignal(anim.finished, timeout=500):
+        anim.start()
+
+
+def test_eitem_animation_handles_missing_edge(qtbot: QtBot) -> None:
+    """An EItemAnimation whose target edge is absent from ``edge_map`` must
+    no-op rather than raise. Regression test for #482."""
+    g = new_graph()
+    a = g.add_vertex(VertexType.Z, qubit=0, row=0)
+    b = g.add_vertex(VertexType.Z, qubit=0, row=1)
+    g.add_edge((a, b))
+    scene = GraphScene()
+    scene.set_graph(g)
+    e = next(iter(scene.edge_map))
+
+    anim = EItemAnimation(e, EItem.Properties.Opacity, scene)
+    anim.setStartValue(1.0)
+    anim.setEndValue(0.0)
+    anim.setDuration(50)
+    del scene.edge_map[e]
+
+    assert anim.it is None
+    anim._on_state_changed(QAbstractAnimation.State.Running)
+    anim._on_state_changed(QAbstractAnimation.State.Stopped)
+    anim.updateCurrentValue(0.5)
+    with qtbot.waitSignal(anim.finished, timeout=500):
+        anim.start()

--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -385,21 +385,24 @@ class EItemAnimation(QVariantAnimation):
         self.stateChanged.connect(self._on_state_changed)
 
     @property
-    def it(self) -> EItem:
+    def it(self) -> Optional[EItem]:
+        # Returns ``None`` if the edge is no longer in the scene.
         if self._it is None and self.scene is not None and self.e is not None:
-            self._it = self.scene.edge_map[self.e][0]
-        assert self._it is not None
+            if mapping := self.scene.edge_map.get(self.e):
+                self._it = mapping[0]
         return self._it
 
     def _on_state_changed(self, state: QAbstractAnimation.State) -> None:
-        if state == QAbstractAnimation.State.Running and self not in self.it.active_animations:
+        if (item := self.it) is None:
+            return
+        if state == QAbstractAnimation.State.Running and self not in item.active_animations:
             # Stop all animations that target the same property
-            for anim in self.it.active_animations.copy():
+            for anim in item.active_animations.copy():
                 if anim.prop == self.prop:
                     anim.stop()
-            self.it.active_animations.add(self)
+            item.active_animations.add(self)
         elif state == QAbstractAnimation.State.Stopped:
-            self.it.active_animations.remove(self)
+            item.active_animations.discard(self)
         elif state == QAbstractAnimation.State.Paused:
             # TODO: Once we use pausing, we should decide what to do here.
             #   Note that we cannot just remove ourselves from the set since the garbage
@@ -408,13 +411,13 @@ class EItemAnimation(QVariantAnimation):
             pass
 
     def updateCurrentValue(self, value: Any) -> None:
-        if self.state() != QAbstractAnimation.State.Running:
+        if self.state() != QAbstractAnimation.State.Running or (item := self.it) is None:
             return
 
         if self.prop == EItem.Properties.Thickness:
-            self.it.thickness = value
+            item.thickness = value
         elif self.prop == EItem.Properties.Opacity:
-            self.it.setOpacity(value)
+            item.setOpacity(value)
 
         if self.refresh:
-            self.it.refresh()
+            item.refresh()

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -587,21 +587,23 @@ class VItemAnimation(QVariantAnimation):
         self.stateChanged.connect(self._on_state_changed)
 
     @property
-    def it(self) -> VItem:
+    def it(self) -> Optional[VItem]:
+        # Returns ``None`` if the vertex is no longer in the scene.
         if self._it is None and self.scene is not None and self.v is not None:
-            self._it = self.scene.vertex_map[self.v]
-        assert self._it is not None
+            self._it = self.scene.vertex_map.get(self.v)
         return self._it
 
     def _on_state_changed(self, state: QAbstractAnimation.State) -> None:
-        if state == QAbstractAnimation.State.Running and self not in self.it.active_animations:
+        if (item := self.it) is None:
+            return
+        if state == QAbstractAnimation.State.Running and self not in item.active_animations:
             # Stop all animations that target the same property
-            for anim in self.it.active_animations.copy():
+            for anim in item.active_animations.copy():
                 if anim.prop == self.prop:
                     anim.stop()
-            self.it.active_animations.add(self)
+            item.active_animations.add(self)
         elif state == QAbstractAnimation.State.Stopped:
-            self.it.active_animations.remove(self)
+            item.active_animations.discard(self)
         elif state == QAbstractAnimation.State.Paused:
             # TODO: Once we use pausing, we should decide what to do here.
             #   Note that we cannot just remove ourselves from the set since the garbage
@@ -610,18 +612,18 @@ class VItemAnimation(QVariantAnimation):
             pass
 
     def updateCurrentValue(self, value: Any) -> None:
-        if self.state() != QAbstractAnimation.State.Running:
+        if self.state() != QAbstractAnimation.State.Running or (item := self.it) is None:
             return
 
         if self.prop == VItem.Properties.Position:
-            self.it.setPos(value)
+            item.setPos(value)
         elif self.prop == VItem.Properties.Scale:
-            self.it.setScale(value)
+            item.setScale(value)
         elif self.prop == VItem.Properties.Rect:
-            self.it.setPath(value)
+            item.setPath(value)
 
         if self.refresh:
-            self.it.refresh()
+            item.refresh()
 
 
 class PhaseItem(QGraphicsTextItem):


### PR DESCRIPTION
Make `VItemAnimation`/`EItemAnimation` tolerate a target id that is no longer in the scene's vertex/edge map: the it property returns `None` instead of raising, and the lifecycle hooks early return when `None`.

Fixes #482.