### PR TITLE
Document Proof mode gestures

### DIFF
--- a/doc/_static/wand-add-identity.svg
+++ b/doc/_static/wand-add-identity.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="250" viewBox="0 0 900 250" role="img" aria-labelledby="title desc">
+  <title id="title">Adding an identity spider with the magic wand</title>
+  <desc id="desc">A wire, a wand stroke across the wire, and the resulting wire with a green identity spider.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#4a5568"/>
+    </marker>
+    <style>
+      .label { font: 18px sans-serif; fill: #263238; text-anchor: middle; }
+      .wire { stroke: #202124; stroke-width: 5; stroke-linecap: round; }
+      .wand { stroke: #1976d2; stroke-width: 8; stroke-linecap: round; }
+      .endpoint { fill: #202124; }
+      .spider { fill: #8fd694; stroke: #245c2c; stroke-width: 4; }
+      .arrow { stroke: #4a5568; stroke-width: 4; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <text class="label" x="150" y="40">Before</text>
+  <line class="wire" x1="55" y1="125" x2="245" y2="125"/>
+  <circle class="endpoint" cx="55" cy="125" r="7"/>
+  <circle class="endpoint" cx="245" cy="125" r="7"/>
+
+  <line class="arrow" x1="270" y1="125" x2="335" y2="125"/>
+
+  <text class="label" x="450" y="40">Draw the wand across one wire</text>
+  <line class="wire" x1="355" y1="125" x2="545" y2="125"/>
+  <circle class="endpoint" cx="355" cy="125" r="7"/>
+  <circle class="endpoint" cx="545" cy="125" r="7"/>
+  <line class="wand" x1="430" y1="72" x2="470" y2="178"/>
+
+  <line class="arrow" x1="570" y1="125" x2="635" y2="125"/>
+
+  <text class="label" x="750" y="40">After</text>
+  <line class="wire" x1="655" y1="125" x2="845" y2="125"/>
+  <circle class="endpoint" cx="655" cy="125" r="7"/>
+  <circle class="endpoint" cx="845" cy="125" r="7"/>
+  <circle class="spider" cx="750" cy="125" r="22"/>
+  <text class="label" x="750" y="205">Z identity (X is also available)</text>
+</svg>

--- a/doc/_static/wand-unfuse.svg
+++ b/doc/_static/wand-unfuse.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="300" viewBox="0 0 900 300" role="img" aria-labelledby="title desc">
+  <title id="title">Unfusing a spider with the magic wand</title>
+  <desc id="desc">A four-legged green spider, a wand stroke through it, and two connected green spiders with the legs divided between them.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#4a5568"/>
+    </marker>
+    <style>
+      .label { font: 18px sans-serif; fill: #263238; text-anchor: middle; }
+      .wire { stroke: #202124; stroke-width: 5; stroke-linecap: round; }
+      .wand { stroke: #1976d2; stroke-width: 8; stroke-linecap: round; }
+      .endpoint { fill: #202124; }
+      .spider { fill: #8fd694; stroke: #245c2c; stroke-width: 4; }
+      .arrow { stroke: #4a5568; stroke-width: 4; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <text class="label" x="150" y="35">Before</text>
+  <line class="wire" x1="65" y1="80" x2="150" y2="145"/>
+  <line class="wire" x1="65" y1="220" x2="150" y2="155"/>
+  <line class="wire" x1="235" y1="80" x2="150" y2="145"/>
+  <line class="wire" x1="235" y1="220" x2="150" y2="155"/>
+  <circle class="endpoint" cx="65" cy="80" r="7"/>
+  <circle class="endpoint" cx="65" cy="220" r="7"/>
+  <circle class="endpoint" cx="235" cy="80" r="7"/>
+  <circle class="endpoint" cx="235" cy="220" r="7"/>
+  <circle class="spider" cx="150" cy="150" r="24"/>
+
+  <line class="arrow" x1="270" y1="150" x2="335" y2="150"/>
+
+  <text class="label" x="450" y="35">Draw through the spider</text>
+  <line class="wire" x1="365" y1="80" x2="450" y2="145"/>
+  <line class="wire" x1="365" y1="220" x2="450" y2="155"/>
+  <line class="wire" x1="535" y1="80" x2="450" y2="145"/>
+  <line class="wire" x1="535" y1="220" x2="450" y2="155"/>
+  <circle class="endpoint" cx="365" cy="80" r="7"/>
+  <circle class="endpoint" cx="365" cy="220" r="7"/>
+  <circle class="endpoint" cx="535" cy="80" r="7"/>
+  <circle class="endpoint" cx="535" cy="220" r="7"/>
+  <circle class="spider" cx="450" cy="150" r="24"/>
+  <line class="wand" x1="450" y1="92" x2="450" y2="208"/>
+
+  <line class="arrow" x1="570" y1="150" x2="635" y2="150"/>
+
+  <text class="label" x="750" y="35">After</text>
+  <line class="wire" x1="665" y1="80" x2="710" y2="150"/>
+  <line class="wire" x1="665" y1="220" x2="710" y2="150"/>
+  <line class="wire" x1="790" y1="150" x2="835" y2="80"/>
+  <line class="wire" x1="790" y1="150" x2="835" y2="220"/>
+  <line class="wire" x1="710" y1="150" x2="790" y2="150"/>
+  <circle class="endpoint" cx="665" cy="80" r="7"/>
+  <circle class="endpoint" cx="665" cy="220" r="7"/>
+  <circle class="endpoint" cx="835" cy="80" r="7"/>
+  <circle class="endpoint" cx="835" cy="220" r="7"/>
+  <circle class="spider" cx="710" cy="150" r="24"/>
+  <circle class="spider" cx="790" cy="150" r="24"/>
+  <text class="label" x="750" y="270">The stroke divides the incident wires</text>
+</svg>

--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -85,7 +85,7 @@ Applying the bialgebra rule to two complementary spiders.
 
 Notice that an entry has been added into the rewrite history panel on the right. You can click "START" up the top right to preview the previous state of the graph before applying the bialgebra rule.
 
-Now drag the adjacent Z and X spiders together to fuse them. Notice that there are some spiders with only two legs and are therefore are equal to the identity. We can remove these by either selecting the spider and clicking the "Basic rules > remove identity" rule in the rule panel on the left, or we could use the magic wand (`w`) and draw the wand over the identity to remove it.
+Now drag adjacent spiders of the same type together to fuse them. Notice that there are some spiders with only two legs and are therefore equal to the identity. We can remove these by either selecting the spider and clicking the "Basic rules > Remove identity" rule in the rule panel on the left, or by using the magic wand (`w`) and drawing the wand through the identity.
 
 ```{figure} _static/simplify_graph.gif
 :alt: Merging spiders and removing identities
@@ -94,7 +94,7 @@ Now drag the adjacent Z and X spiders together to fuse them. Notice that there a
 Simplify the graph by merge spiders of the same type and removing identity spiders.
 ```
 
-Apply these techniques one more time to reduce the diagram to the SWAP operation. Notice in the animation before that after merging the X spiders, there should be two edges between the resulting Z and X spider --- however they both disappear. This is because ZXLive automatically applied the Hopf algebra rule to eliminate double wires between complementary spiders.
+Apply these techniques one more time to reduce the diagram to the SWAP operation. When merging the X spiders creates parallel edges between complementary spiders, use the magic wand (`w`) and draw across the parallel edges to apply the Hopf rule and remove them in pairs.
 
 ```{figure} _static/simplify_to_swap.gif
 :alt: Simplify the graph to a SWAP
@@ -104,3 +104,5 @@ Simplify the graph to a SWAP.
 ```
 
 Our proof is now complete and we could either save it as a proof file ("File > Save") which could be loaded by ZXLive again later, or we could export the proof to tikz to be included in a LaTex document by selecting "File > Export to Tikz".
+
+For a complete reference to drag-and-drop, double-click, and magic-wand rewrites, see [Proof mode gestures](proof-mode-gestures.md).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@ Welcome to zxlive's documentation!
    :caption: Contents:
 
    gettingstarted
+   proof-mode-gestures
    adding-rewrites
    tikz_export
 

--- a/doc/proof-mode-gestures.md
+++ b/doc/proof-mode-gestures.md
@@ -1,0 +1,146 @@
+# Proof mode gestures
+
+Proof mode turns every diagram change into a ZX rewrite. You can choose a rule
+from the panel on the left, but the most common rewrites are also available as
+direct gestures on the diagram.
+
+```{figure} _static/proof_window_toolbar.png
+:alt: The Proof window toolbar
+:align: center
+
+The Proof toolbar. Use Select (`s`) for drag-and-drop and double-click gestures,
+or the Magic wand (`w`) for stroke gestures. The Z/X toggle chooses the identity
+spider added by the wand.
+```
+
+Every successful gesture adds a step to the rewrite history on the right. If a
+gesture does not match a valid rewrite, it leaves the diagram unchanged (or
+just moves the dragged spider).
+
+## Quick reference
+
+| Gesture | Result | Important condition |
+| --- | --- | --- |
+| Drag one spider onto another | Fuse spiders | The connected spiders have the same colour |
+| Drag a single-legged 0/π spider onto its neighbour | Copy the 0/π spider | The copy rewrite is valid |
+| Drag a π-phase Z/X spider onto its neighbour | Push the Pauli spider | The Pauli rewrite is valid for that pair |
+| Drag one spider onto another | Apply strong complementarity (bialgebra) | The pair satisfies the strong-complementarity conditions |
+| Double-click a Z or X spider | Change its colour | Hadamard edges are introduced as required |
+| Double-click a Hadamard edge or eligible H-box | Toggle between the edge and H-box forms | The selected item represents a valid Hadamard |
+| Draw the wand through a spider | Unfuse the spider | The stroke decides how its incident wires are divided |
+| Draw the wand through a two-legged, zero-phase spider | Remove the identity spider | Hold Shift to unfuse it instead |
+| Draw the wand across one wire | Add an identity spider | The Z/X toolbar toggle chooses its colour |
+| Draw the wand across parallel wires | Apply the Hopf rule | The crossed wires form cancellable pairs |
+
+When several drag-and-drop rewrites could match, ZXLive tries them in this
+order: **fusion**, **copy 0/π**, **push Pauli**, then **strong
+complementarity**.
+
+## Drag-and-drop rewrites
+
+Press `s` to select the **Select** tool, then drag a spider onto another
+spider. The target is highlighted when ZXLive recognises a direct rewrite.
+
+### Fusion and strong complementarity
+
+Dragging two connected spiders of the **same colour** together fuses them and
+adds their phases. Dragging connected, complementary-colour Z/X spiders with
+Pauli phases together can instead apply strong complementarity (also called
+bialgebra). ZXLive also supports the corresponding rewrite for a compatible X
+spider and standard H-box.
+
+```{figure} _static/bialgebra.gif
+:alt: Applying strong complementarity by dragging complementary spiders together
+:align: center
+
+Dragging complementary spiders together to apply strong complementarity.
+```
+
+```{figure} _static/simplify_graph.gif
+:alt: Fusing spiders and removing identities
+:align: center
+
+Fusing same-coloured spiders, then removing the resulting identities.
+```
+
+### Copy 0/π and push Pauli
+
+Two other rewrites use the same drag-and-drop gesture:
+
+- **Copy 0/π spider through its neighbour** applies to a single-legged spider
+  whose phase is 0 or π.
+- **Push Pauli** applies to a π-phase Z/X spider and a compatible neighbour.
+
+These names match the entries in the **Basic rules** panel. A 0/π spider may
+also satisfy another rewrite, so use the highlighted preview and the rewrite
+history to confirm which action will be applied.
+
+## Double-click rewrites
+
+With the Select tool active:
+
+- Double-click a Z or X spider to apply colour change. Its colour flips and
+  its incident edge types change as required.
+- Double-click a Hadamard edge to expand it into an explicit H-box.
+- Double-click an eligible H-box to turn it back into a Hadamard edge.
+
+## Magic wand rewrites
+
+Press `w` (or click the wand button), then hold the left mouse button and draw
+a short stroke through the relevant part of the diagram. The wand checks the
+stroke in this order: a spider slice, a single wire, then parallel wires.
+
+### Unfuse or remove a spider
+
+Draw through a spider to split it into two same-coloured spiders. The stroke
+separates the incident wires into two groups, so its angle and position control
+which wires move to each new spider.
+
+By default, drawing through a two-legged, zero-phase spider removes it as an
+identity instead of unfusing it. Hold **Shift** to force unfusion and choose
+the phase assigned to one side of the split; the remaining phase stays on the
+other side.
+
+```{figure} _static/wand-unfuse.svg
+:alt: Unfusing a spider by drawing the magic wand through it
+:align: center
+
+The wand stroke divides the incident wires between two connected spiders.
+```
+
+### Add an identity spider
+
+Draw across exactly one wire without crossing a spider. ZXLive inserts a
+two-legged, zero-phase identity spider where the stroke meets the wire. Choose
+whether it is a Z or X spider with the toggle beside the wand button.
+
+```{figure} _static/wand-add-identity.svg
+:alt: Adding an identity spider by drawing the magic wand across a wire
+:align: center
+
+Adding a Z identity spider; the toolbar toggle can select an X identity instead.
+```
+
+### Apply the Hopf rule
+
+Draw across a bundle of parallel wires between compatible spiders. The wand
+removes the crossed wires in pairs; if the bundle has an odd number of wires,
+one remains.
+
+```{figure} _static/simplify_to_swap.gif
+:alt: Simplifying a diagram with fusion and the Hopf rule
+:align: center
+
+Parallel wires can be cancelled in pairs with the Hopf rule.
+```
+
+## Troubleshooting gestures
+
+- Start a wand stroke on empty canvas. Starting directly on a diagram item can
+  select or move it instead.
+- For fusion, copy, Pauli push, and strong complementarity, drag only one
+  selected spider onto its target.
+- If a wand stroke crosses both a spider and wires, the spider action is tried
+  first.
+- Check the rewrite history after a gesture to see the exact rule that ZXLive
+  applied.

--- a/doc/proof-mode-gestures.md
+++ b/doc/proof-mode-gestures.md
@@ -4,14 +4,11 @@ Proof mode turns every diagram change into a ZX rewrite. You can choose a rule
 from the panel on the left, but the most common rewrites are also available as
 direct gestures on the diagram.
 
-```{figure} _static/proof_window_toolbar.png
-:alt: The Proof window toolbar
-:align: center
+![The Proof window toolbar](./_static/proof_window_toolbar.png)
 
-The Proof toolbar. Use Select (`s`) for drag-and-drop and double-click gestures,
-or the Magic wand (`w`) for stroke gestures. The Z/X toggle chooses the identity
-spider added by the wand.
-```
+*The Proof toolbar. Use Select (`s`) for drag-and-drop and double-click
+gestures, or the Magic wand (`w`) for stroke gestures. The Z/X toggle chooses
+the identity spider added by the wand.*
 
 Every successful gesture adds a step to the rewrite history on the right. If a
 gesture does not match a valid rewrite, it leaves the diagram unchanged (or
@@ -49,19 +46,13 @@ Pauli phases together can instead apply strong complementarity (also called
 bialgebra). ZXLive also supports the corresponding rewrite for a compatible X
 spider and standard H-box.
 
-```{figure} _static/bialgebra.gif
-:alt: Applying strong complementarity by dragging complementary spiders together
-:align: center
+![Applying strong complementarity by dragging complementary spiders together](./_static/bialgebra.gif)
 
-Dragging complementary spiders together to apply strong complementarity.
-```
+*Dragging complementary spiders together to apply strong complementarity.*
 
-```{figure} _static/simplify_graph.gif
-:alt: Fusing spiders and removing identities
-:align: center
+![Fusing spiders and removing identities](./_static/simplify_graph.gif)
 
-Fusing same-coloured spiders, then removing the resulting identities.
-```
+*Fusing same-coloured spiders, then removing the resulting identities.*
 
 ### Copy 0/π and push Pauli
 
@@ -101,12 +92,9 @@ identity instead of unfusing it. Hold **Shift** to force unfusion and choose
 the phase assigned to one side of the split; the remaining phase stays on the
 other side.
 
-```{figure} _static/wand-unfuse.svg
-:alt: Unfusing a spider by drawing the magic wand through it
-:align: center
+![Unfusing a spider by drawing the magic wand through it](./_static/wand-unfuse.svg)
 
-The wand stroke divides the incident wires between two connected spiders.
-```
+*The wand stroke divides the incident wires between two connected spiders.*
 
 ### Add an identity spider
 
@@ -114,12 +102,9 @@ Draw across exactly one wire without crossing a spider. ZXLive inserts a
 two-legged, zero-phase identity spider where the stroke meets the wire. Choose
 whether it is a Z or X spider with the toggle beside the wand button.
 
-```{figure} _static/wand-add-identity.svg
-:alt: Adding an identity spider by drawing the magic wand across a wire
-:align: center
+![Adding an identity spider by drawing the magic wand across a wire](./_static/wand-add-identity.svg)
 
-Adding a Z identity spider; the toolbar toggle can select an X identity instead.
-```
+*Adding a Z identity spider; the toolbar toggle can select an X identity instead.*
 
 ### Apply the Hopf rule
 
@@ -127,12 +112,9 @@ Draw across a bundle of parallel wires between compatible spiders. The wand
 removes the crossed wires in pairs; if the bundle has an odd number of wires,
 one remains.
 
-```{figure} _static/simplify_to_swap.gif
-:alt: Simplifying a diagram with fusion and the Hopf rule
-:align: center
+![Simplifying a diagram with fusion and the Hopf rule](./_static/simplify_to_swap.gif)
 
-Parallel wires can be cancelled in pairs with the Hopf rule.
-```
+*Parallel wires can be cancelled in pairs with the Hopf rule.*
 
 ## Troubleshooting gestures
 


### PR DESCRIPTION
## Summary

- add a source-backed Proof mode gesture reference covering drag-and-drop, double-click, and magic-wand rewrites
- reuse existing operation recordings and add lightweight SVG diagrams for adding identities and unfusing spiders
- link the guide from the documentation index and Getting Started tutorial
- correct the tutorial's same-type fusion and Hopf descriptions so they match the actual Proof mode interactions

## Validation

- `sphinx-build -W --keep-going -D suppress_warnings=toc.not_included -E -b html doc doc/_build/strict-html`
- normal Sphinx HTML build
- browser smoke check of the generated guide, responsive table, links, and all six images
- validated the added SVG files as XML

The only suppressed warning is the repository's pre-existing `doc/pauli-webs.md` not-in-toctree warning.

## AI disclosure

I used OpenAI Codex for repository navigation, source verification, drafting, and validation support. I manually reviewed the gesture contracts against the implementation and inspected the rendered documentation.

Closes #522.