### PR TITLE
Bump Python version to 3.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ 3.11 ]
+        python-version: [ 3.12 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches: [ master ]
-  pull_request: 
+  pull_request:
     branches: [ master ]
 
 env:
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - run: pip install ".[test]"
       - run: mypy zxlive
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - run: pip install ruff
       - run: ruff check
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
       - run: pip install ruff complexipy
       - name: Ruff - Cyclomatic Complexity

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ 3.11 ]
+        python-version: [ 3.12 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.11' ]
+        python-version: [ '3.12' ]
     env:
       DISPLAY: ':99.0'
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is in a pretty early stage, with lots more to come. Have a look at 
 
 To install the latest stable release, you can download the binaries from the [releases page](https://github.com/zxcalc/zxlive/releases).
 
-To install from source, you need Python >= 3.9 and pip. If you have those, just run:
+To install from source, you need Python >= 3.12 and pip. If you have those, just run:
 
     git clone https://github.com/zxcalc/zxlive.git
     cd zxlive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "zxlive"
 version = "1.0.0"
 description = "An interactive tool for the ZX-calculus"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 authors = [
     { name = "ZXLive contributors" },
@@ -22,9 +22,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering"
@@ -96,7 +93,7 @@ ignore = [
 combine-as-imports = true
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-    "PySide6 >= 6.7.2",
-    "pyzx >= 0.10.0",
+    "PySide6>=6.7.2",
+    "pyzx>=0.10.4",
     "networkx",
     "numpy",
     "shapely",
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "mypy==1.19.1",
+    "mypy>=2.3.0",
     "ruff",
     "pytest-qt",
     "complexipy",

--- a/zxlive/custom_rule.py
+++ b/zxlive/custom_rule.py
@@ -36,7 +36,7 @@ class CustomRule(RewriteSimpGraph[VT, ET]):
         self.rhs_graph_nx = to_networkx(rhs_graph)
         self.name = name
         self.description = description
-        self.last_rewrite_center = None
+        self.last_rewrite_center: tuple[int, int] | None = None
         self.is_rewrite_unfusable = is_rewrite_unfusable(lhs_graph)
         if self.is_rewrite_unfusable:
             self.lhs_graph_without_boundaries_nx = nx.MultiGraph(self.lhs_graph_nx.subgraph(
@@ -76,7 +76,8 @@ class CustomRule(RewriteSimpGraph[VT, ET]):
 
         vertex_positions = get_vertex_positions(graph, self.rhs_graph_nx, boundary_vertex_map)
         if boundary_vertex_map:
-            self.last_rewrite_center = np.mean([(graph.row(m), graph.qubit(m)) for m in boundary_vertex_map.values()], axis=0)
+            mean = np.mean([(graph.row(m), graph.qubit(m)) for m in boundary_vertex_map.values()], axis=0)
+            self.last_rewrite_center = (int(mean[0]), int(mean[1]))
         else:
             self.last_rewrite_center = None
         vertex_map = dict(boundary_vertex_map)


### PR DESCRIPTION
Closes #547.

Updates the minimum Python version for running ZXLive to Python 3.12 (previously Python 3.9). Also updates the corresponding versions in the tooling and GitHub workflows.

There are various comments throughout the code detailing small changes to make once the code was upgraded to 3.10 or 3.11, which I'm happy to either bundle into this PR or open a separate PR for.