### PR TITLE
Fix magic wand Hopf rule matching

### DIFF
--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -336,7 +336,7 @@ class ProofPanel(BasePanel):
         # vertices should be different types, or edge should be hadamard
         match edge_type:
             case EdgeType.HADAMARD:
-                is_match = (vertex_is_z_like(source_type) and vertex_is_z_like(target_type))
+                is_match = (vertex_is_z_like(source_type) == vertex_is_z_like(target_type))
             case EdgeType.SIMPLE:
                 is_match = (vertex_is_z_like(source_type) and target_type == VertexType.X) or (source_type == VertexType.X and vertex_is_z_like(target_type))
             case _:
@@ -344,7 +344,7 @@ class ProofPanel(BasePanel):
         
         # we also need at least two edges
         num_edges = len(edges)
-        if is_match and (num_edges >= 2):
+        if not is_match or num_edges < 2:
             return False
         
         new_g = copy.deepcopy(self.graph)

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -338,7 +338,7 @@ class ProofPanel(BasePanel):
         edge_type = self.graph.edge_type(edges[0])
         match edge_type:
             case EdgeType.HADAMARD:
-                is_match = (vertex_is_z_like(source_type) == vertex_is_z_like(target_type))
+                is_match = (vertex_is_z_like(source_type) and vertex_is_z_like(target_type)) or (source_type == target_type == VertexType.X)
             case EdgeType.SIMPLE:
                 is_match = (vertex_is_z_like(source_type) and target_type == VertexType.X) or (source_type == VertexType.X and vertex_is_z_like(target_type))
             case _:

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -322,18 +322,20 @@ class ProofPanel(BasePanel):
             return
 
     def _magic_hopf(self, trace: WandTrace) -> bool:
-        if not all(isinstance(item, EItem) for item in trace.hit):
+        # Check that all traced items are edges
+        edges: list[ET] = [item.e for item in trace.hit if isinstance(item, EItem)]
+        if len(edges) != len(trace.hit):
             return False
-        edges: list[ET] = [item.e for item in trace.hit]  # type: ignore  # We know that the type of `item` is `EItem` because of the check above
-        if len(edges) == 0:
+        
+        # Check that we traced 2+ edges of identical types
+        num_edges = len(edges)
+        if num_edges < 2 or not all(edge == edges[0] for edge in edges):
             return False
-        if not all(edge == edges[0] for edge in edges):
-            return False
+        
+        # Check that vertices are the same type if the edge is Hadamard, or different types if edge is simple
         source, target = self.graph.edge_st(edges[0])
         source_type, target_type = self.graph.type(source), self.graph.type(target)
         edge_type = self.graph.edge_type(edges[0])
-        
-        # vertices should be different types, or edge should be hadamard
         match edge_type:
             case EdgeType.HADAMARD:
                 is_match = (vertex_is_z_like(source_type) == vertex_is_z_like(target_type))
@@ -342,9 +344,7 @@ class ProofPanel(BasePanel):
             case _:
                 is_match = False
         
-        # we also need at least two edges
-        num_edges = len(edges)
-        if not is_match or num_edges < 2:
+        if not is_match:
             return False
         
         new_g = copy.deepcopy(self.graph)


### PR DESCRIPTION
Fixes two bugs in the magic wand Hopf rule matching: one was introduced by a refactor in #550 which inverted an if statement, and another was a pre-existing bug which caused the magic wand to fail to match X-spiders connected by multiple Hadamard edges. Additionally cleans up the code in the function a little bit to remove an avoidable `#type: ignore`.